### PR TITLE
Add macOS -Xlinker flag to suppress a linker warning

### DIFF
--- a/makefile
+++ b/makefile
@@ -2592,6 +2592,11 @@ macosx+krb5+openssl macosx10.5+krb5+openssl macosx10.6+krb5+openssl:
 # If you are, and want the server to make Wtmp log entries, do
 # 'make macos "KFLAGS=-UNOWTMP".
 #
+# -Xlinker flags added to LIBS to supress the following warning:
+# ld: warning: reducing alignment of section __DATA,__common
+#     from 0x8000 to 0x4000 because it exceeds segment maximum alignment
+# (Tested on macOS 26.6)
+#
 macos:
 	@MACOSNAME=`/usr/bin/sw_vers -productName`; \
 	MACOSV=`/usr/bin/sw_vers -productVersion`; \
@@ -2607,7 +2612,7 @@ macos:
 	-funsigned-char -DNODCLINITGROUPS \
 	-DNOUUCP -O -DHERALD=\"\\\" $${MACOSNAME} $${MACOSV}\\\"\" \
 	-DCKCPU=\"\\\"$${MACCPU}\\\"\" \
-	$(KFLAGS)" "LIBS= -lncurses -lresolv $(LIBS)"
+	$(KFLAGS)" "LIBS= -lncurses -lresolv -Xlinker -max_default_common_align -Xlinker 0x4000 $(LIBS)"
 
 # Experimental.  2022-11-30  SMS.
 macos+ssl macos+openssl:


### PR DESCRIPTION
# Pull request summary

The patch in this pull request suppresses the following warning message on macOS build with `make clean macos`:

```text
ld: warning: reducing alignment of section __DATA,__common from 0x8000 to 0x4000 because it exceeds segment maximum alignment
```

## How to reproduce

`make clean macos`

## What this patch will change

After the patch, the error message will not show up.

## Compatibility

This patch will not affect other OS builds other than macOS.

## Reference

* [Blender: Build: macOS: Suppress linker __common symbol section exceeding alignment warning](https://projects.blender.org/blender/blender/commit/524f31ec79b50b9fccc08884ffd603adca85a03d)
* [A commit in my own C-Kermit modification project testing the linker modification](https://github.com/jj1bdx/simplified-c-kermit/commit/d2555d1c711ca779696097ba65c050f066eea15f)