### PR TITLE
Properly define CK_WREFRESH on Linux and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
   # boot a QEMU VM inside the ubuntu-latest runner via vmactions.
   freebsd-x86_64:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -252,6 +253,7 @@ jobs:
 
   netbsd-x86_64:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -306,6 +308,7 @@ jobs:
 
   openbsd-x86_64:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 

--- a/ckcdeb.h
+++ b/ckcdeb.h
@@ -6110,6 +6110,12 @@ _PROTOTYP( char *GetLoadPath, (void) );
 #ifdef BSD44				/* 4.4 BSD has it */
 #define CK_WREFRESH
 #else
+#ifdef LINUX				/* Linux (ncurses) has it too */
+#define CK_WREFRESH
+#else
+#ifdef MACOSX10				/* macOS (ncurses) has it too */
+#define CK_WREFRESH
+#else
 #ifdef NEXT				/* Define it for NeXTSTEP */
 #define CK_WREFRESH
 #else
@@ -6136,6 +6142,8 @@ _PROTOTYP( char *GetLoadPath, (void) );
 #endif /* SOLARIS25 */
 #endif /* SUNOS4 */
 #endif /* NEXT */
+#endif /* MACOSX10 */
+#endif /* LINUX */
 #endif /* BSD44 */
 #endif /* SVR3 */
 #endif /* ultrix */

--- a/ckuus2.c
+++ b/ckuus2.c
@@ -6211,6 +6211,341 @@ dohfile(cx) int cx;
 }
 #endif /* CKCHANNELIO */
 
+#ifndef NOSHOW
+static char *hmxxsho[] = {
+"Display current values of various items (SET parameters, variables, etc).",
+"The categories are listed below.",
+" ",
+#ifndef NOSPL
+"SHOW ALARM",
+"  Shows the time an ALARM is set to go off, if any.",
+" ",
+"SHOW ARGUMENTS",
+"  Shows the arguments of the active macro, or the command-line",
+"  arguments Kermit was started with, if not executing a macro.",
+" ",
+"SHOW ARRAYS",
+"  Lists the names, dimensions, and sizes of all defined arrays.",
+" ",
+#endif /* NOSPL */
+#ifndef NOCSETS
+"SHOW ASSOCIATIONS",
+"  Lists the FILE-CHARACTER-SET and XFER-CHARACTER-SET associations",
+"  established by the ASSOCIATE command.  See also SHOW CHARACTER-SETS.",
+" ",
+#endif /* NOCSETS */
+#ifndef NOXFER
+"SHOW ATTRIBUTES",
+"  Shows which file attributes are sent and accepted during file transfer.",
+" ",
+#endif /* NOXFER */
+#ifndef NOPUSH
+#ifdef BROWSER
+"SHOW BROWSER",
+"  Shows the name and options of the Web browser invoked by BROWSE.",
+" ",
+#endif /* BROWSER */
+#endif /* NOPUSH */
+"SHOW CD",
+"  Shows the current working directory.",
+" ",
+"SHOW CHARACTER-SETS",
+"  Shows file, terminal, and transfer character sets.  See also",
+"  SHOW ASSOCIATIONS.",
+" ",
+#ifndef NOLOCAL
+"SHOW COMMUNICATIONS",
+"  Shows the parameters of the communication device, such as",
+"  speed, parity, and flow control.",
+" ",
+#endif /* NOLOCAL */
+"SHOW COMMAND",
+"  Shows command mode parameters such as the prompt, command width,",
+"  and command echo.",
+" ",
+"SHOW CONNECTION",
+"  Shows the parameters of the active or most recent host connection.",
+" ",
+#ifdef CK_SPEED
+"SHOW CONTROL-PREFIXING",
+"  Shows the control character and 8-bit prefixing table used",
+"  for file transfer.",
+" ",
+#endif /* CK_SPEED */
+#ifndef NOSPL
+"SHOW COUNT",
+"  Shows the value of the count register used for counted loops.",
+" ",
+#endif /* NOSPL */
+#ifdef VMS
+"SHOW DEFAULT",
+"  Shows the default device and directory.",
+" ",
+#endif /* VMS */
+#ifndef NODIAL
+"SHOW DIAL",
+"  Shows modem dialing parameters, such as dial method,",
+"  prefixes, and timeouts.",
+" ",
+#endif /* NODIAL */
+"SHOW DOUBLE or SHOW IGNORE",
+"  Lists any characters set to be doubled when sent and ignored when",
+"  received, for the current transfer character set.  See SET SEND DOUBLE",
+"  and SET RECEIVE IGNORE.",
+" ",
+#ifndef NOPUSH
+#ifndef NOFRILLS
+"SHOW EDITOR",
+"  Shows the external text editor and options invoked by the EDIT command.",
+" ",
+#endif /* NOFRILLS */
+#endif /* NOPUSH */
+#ifndef NOLOCAL
+"SHOW ESCAPE",
+"  Shows the CONNECT mode escape character.",
+" ",
+#endif /* NOLOCAL */
+"SHOW EXIT",
+"  Shows the exit warning, exit message, and other settings that govern when",
+"  Kermit exits and what happens when it does so.",
+" ",
+"SHOW FEATURES",
+"  Lists the optional features that are compiled into this version of Kermit.",
+" ",
+"SHOW FILE",
+"  Shows file-related parameters such as type, names, and collision handling.",
+" ",
+#ifndef NOLOCAL
+"SHOW FLOW-CONTROL",
+"  Shows the current and default flow control settings for each",
+"  connection type.",
+" ",
+#endif /* NOLOCAL */
+#ifdef BROWSER
+"SHOW FTP",
+"  Shows settings for the built-in FTP client.",
+" ",
+#else
+#ifndef NOFTP
+#ifndef SYSFTP
+#ifdef TCPSOCKET
+"SHOW FTP",
+"  Shows settings for the built-in FTP client.",
+" ",
+#endif /* TCPSOCKET */
+#endif /* SYSFTP */
+#endif /* NOFTP */
+#endif /* BROWSER */
+#ifndef NOSPL
+"SHOW FUNCTIONS",
+"  Lists the built-in functions, or those whose names match a given",
+"  pattern.",
+" ",
+"SHOW GLOBALS",
+"  Lists all global variables.",
+" ",
+#endif /* NOSPL */
+#ifdef KUI
+"SHOW GUI",
+"  Shows graphical user interface settings.",
+" ",
+#endif /* KUI */
+#ifdef CK_RECALL
+"SHOW HISTORY",
+"  Shows the command history.",
+" ",
+#endif /* CK_RECALL */
+#ifndef NOSPL
+"SHOW INPUT",
+"  Shows the parameters used by the INPUT command, such as timeout",
+"  and case sensitivity.",
+" ",
+#endif /* NOSPL */
+#ifdef CK_GETIFADDRS
+"SHOW INTERFACES",
+"  Lists the network interfaces on the local system and their IP addresses.",
+" ",
+#endif /* CK_GETIFADDRS */
+#ifndef NOSETKEY
+"SHOW KEY",
+"  Shows what a given key is mapped to.  Press the key when prompted.",
+" ",
+#ifndef NOKVERBS
+"SHOW KVERBS",
+"  Lists the available keyboard verbs, which can be assigned to keys.",
+" ",
+#endif /* NOKVERBS */
+#endif /* NOSETKEY */
+#ifdef CK_LABELED
+"SHOW LABELED-FILE-INFO",
+"  Shows labeled file information settings.",
+" ",
+#endif /* CK_LABELED */
+#ifndef NOCSETS
+"SHOW LANGUAGES",
+"  Shows language and character set settings",
+" ",
+#ifndef NO_LOCALE
+"SHOW LOCALE",
+"  Shows locale settings.",
+" ",
+#endif /* NO_LOCALE */
+#endif /* NOCSETS */
+"SHOW LOGS",
+"  Lists the log files that are open, if any.",
+" ",
+#ifndef NOSPL
+"SHOW MACROS",
+"  Lists macros or shows the definition of a given macro.",
+" ",
+#endif /* NOSPL */
+#ifndef NODIAL
+"SHOW MODEM",
+"  Shows modem type and related dialing signals.",
+" ",
+#endif /* NODIAL */
+#ifndef NOLOCAL
+#ifdef OS2MOUSE
+"SHOW MOUSE",
+"  Shows mouse settings.",
+" ",
+#endif /* OS2MOUSE */
+#endif /* NOLOCAL */
+#ifdef NETCONN
+"SHOW NETWORK",
+"  Shows network type and related settings, including TCP and TELNET.",
+" ",
+#endif /* NETCONN */
+"SHOW OPTIONS",
+"  Shows settings for the DELETE, DIRECTORY, PURGE, and TYPE commands.",
+" ",
+#ifdef ANYX25
+#ifndef IBMX25
+"SHOW PAD",
+"  Shows X.25 PAD parameters.",
+" ",
+#endif /* IBMX25 */
+#endif /* ANYX25 */
+#ifdef PATTERNS
+"SHOW PATTERNS",
+"  Shows pattern-matching related settings.",
+" ",
+#endif /* PATTERNS */
+"SHOW PRINTER",
+"  Shows printer settings.",
+" ",
+#ifndef NOXFER
+"SHOW PROTOCOL",
+"  Shows Kermit file transfer protocol parameters.",
+" ",
+#endif /* NOXFER */
+"SHOW RENAME",
+"  Shows the settings for the RENAME command.",
+" ",
+#ifndef NOSPL
+"SHOW SCRIPTS",
+"  Shows settings related to command and script execution, such as",
+"  quoting, echoing, and error handling.",
+" ",
+#endif /* NOSPL */
+"SHOW SEND-LIST",
+"  Lists the files queued to be sent by the MSEND command.",
+" ",
+#ifndef NOSERVER
+"SHOW SERVER",
+"  Shows server protocol permissions (see ENABLE and DISABLE).",
+" ",
+#endif /* NOSERVER */
+#ifndef NOSEXP
+"SHOW SEXPRESSION",
+"  Shows S-expression evaluation settings.",
+" ",
+#endif /* NOSEXP */
+#ifdef ANYSSH
+"SHOW SSH",
+"  Shows Secure Shell (SSH) settings.",
+" ",
+#endif /* ANYSSH */
+"SHOW STACK",
+"  Shows the macro invocation stack.",
+" ",
+"SHOW STATUS",
+"  Shows whether the most recent command succeeded or failed.",
+" ",
+#ifdef STREAMING
+"SHOW STREAMING",
+"  Shows streaming and reliable connection settings.",
+" ",
+#endif /* STREAMING */
+#ifndef NOLOCAL
+#ifdef CK_TAPI
+"SHOW TAPI",
+"  Shows TAPI (Telephony API) settings.",
+" ",
+#endif /* CK_TAPI */
+"SHOW TCP",
+"  Shows TCP/IP settings.",
+" ",
+#ifdef TNCODE
+"SHOW TELNET",
+"  Shows TELNET protocol settings.",
+" ",
+"SHOW TELOPT",
+"  Shows the negotiated state of each TELNET option.",
+" ",
+"SHOW TEMP-DIRECTORY",
+"  Shows the directory used for Kermit's temporary files.",
+" ",
+#endif /* TNCODE */
+"SHOW TERMINAL",
+"  Shows terminal settings and properties.",
+" ",
+#endif /* NOLOCAL */
+#ifndef NOXFER
+"SHOW TRANSFER",
+"  Shows file transfer settings such as transfer display,",
+"  mode, and character set translation.",
+" ",
+#endif /* NOXFER */
+#ifndef NOXMIT
+"SHOW TRANSMIT",
+"  Shows the settings for the TRANSMIT command.",
+" ",
+#endif /* NOXMIT */
+#ifdef CK_TRIGGER
+"SHOW TRIGGER",
+"  Lists defined triggers and the most recent one seen.",
+" ",
+#endif /* CK_TRIGGER */
+#ifndef NOSETKEY
+#ifndef NOKVERBS
+#ifdef OS2
+"SHOW UDK",
+"  Lists user-defined keys.",
+" ",
+#endif /* OS2 */
+#endif /* NOKVERBS */
+#endif /* NOSETKEY */
+#ifndef NOSPL
+"SHOW VARIABLES",
+"  Lists the built-in variables, or those whose names match a given",
+"  pattern.",
+" ",
+#endif /* NOSPL */
+#ifndef NOFRILLS
+"SHOW VERSIONS",
+"  Shows the version numbers of Kermit and its major components.",
+" ",
+#endif /* NOFRILLS */
+#ifdef VMS
+"SHOW VMS_TEXT",
+"  Shows VMS text file conversion settings.",
+" ",
+#endif /* VMS */
+""
+};
+#endif /* NOSHOW */
+
 int
 #ifdef CK_ANSIC
 dohlp( int xx )
@@ -6842,9 +7177,7 @@ case XXREXX:
 
 #ifndef NOSHOW
 case XXSHO:
-    return(hmsg("\
-  Display current values of various items (SET parameters, variables, etc).\n\
-  Type SHOW ? for a list of categories."));
+    return(hmsga(hmxxsho));
 #endif /* NOSHOW */
 
 case XXSPA:

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
 
 - Skip FTP tests when Kermit is built with -DNOFTP, as the Gentoo package does.
 - Address macOS linker warning.  Patch from jj1bdx.
+- Added help text for `HELP SHOW`, describing each sub-option.
 
 # C-Kermit 11.0.505
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,23 @@
 - Skip FTP tests when Kermit is built with -DNOFTP, as the Gentoo package does.
 - Address macOS linker warning.  Patch from jj1bdx.
 - Added help text for `HELP SHOW`, describing each sub-option.
+- Properly define CK_WREFRESH on Linux and macOS.  The original definition dates
+  to 1994 and appears to have just never been udpated for these platforms.
+- C-Kermit now is fully able to process filenames with embedded spaces due to numerous bugfixes.  Among them:
+  - You can now use `GET` to retrieve a file whose name has embedded spaces
+    (previously you could only `SEND` such a file).
+  - `MGET` had bugs around quoting that inadvertantly would strip necessary quote characters.
+  - The Kermit Protocol treats a space as a delimeter between filenames, unless
+    it is enclosed in braces.  The C-Kermit client accepts both double quotes
+    and braces as quoting characters.  The client now will properly quote all
+    filenames containing spaces with braces when sent to the server, regardless
+    of which scheme the user selected.
+  - Several `REMOTE` commands were broken with filenames with embedded spaces or
+    escaped delimiters.
+  - Numerous bugs relating to escaping of embedded quote/brace characters as
+    part of filenames were fixed.
+  - `GET` and `SEND` used inconsistent quoting rules.
+  
 
 # C-Kermit 11.0.505
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -223,11 +223,11 @@ relationship between the different Kermit versions.
   data corruption, letting Kermit always follow the user's expressed transfer
   type wishes by default.
 
-- [11] Fix insecure defaults that previously would let a malicious remote kermit
-  server perform actions on your local workstation.  Further discussion in
-  commit 9ee170a85 and full details at http://bugs.debian.org/1123025 .  See
-  more details under changed behavior below for how to adjust this in the rare
-  event you might need to.
+- [11] Fix CVE-2025-68920, insecure defaults that previously would let a
+  malicious remote kermit server perform actions on your local workstation.
+  Further discussion in commit 9ee170a85 and full details at
+  http://bugs.debian.org/1123025 .  See more details under changed behavior
+  below for how to adjust this in the rare event you might need to.
 
 - [11] Switch the default `SET FILE COLLISION` from BACKUP to REJECT.  The
   previous default would let a malicious remote overwrite sensitive local files
@@ -440,15 +440,16 @@ wild.
   TRANSFER-MODE AUTOMATIC`.  See discussion above under security and at
   https://bugs.debian.org/1121901 .
 
-- [11] The set of extensions used when transfer-mode is automatic has been
-  revised with modern filetypes, and had typos corrected.  (976a9742)
+- [11] You may still set transfer-mode to be automatic.  If you do, the sets of
+  extensions used to help determine text or binary files have been revised with
+  modern filetypes, and had typos corrected.  (976a9742)
 
 - [11] When C-Kermit is used as a client, it may connect to an untrusted remote
   system (for instance, a BBS).  By default, the remote Kermit was able to make
   changes to, and retrieve data from, the local system.  This scenario would be
   been used exceptionally rarely for legitimate purposes.  You can type `enable
   ?` to see the list of commands you can re-enable.  See the discussion above
-  under security.  (9ee170a8 and dc67bddb)
+  under CVE-2025-68920.  (9ee170a8 and dc67bddb)
   
 - [11] Since C-Kermit now properly reports errors during autodownload, the
   default for `SET TERMINAL AUTODOWNLOAD ERROR` has changed from `STOP` to

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -32,6 +32,24 @@ recursive transfers to proceed while still blocking other directory-escaping
 attempts.  C-Kermit 11.0 also adds output to `SHOW SERVER` to make it more clear
 to you exactly what controls are operating at any given moment.
 
+## Is the server malicious?
+
+Like many other programs, Kermit was built around the assumption that the remote
+server is at least somewhat trustworthy.  Often times, you know it is.  Maybe
+it's even more trustworthy than your client.
+
+However, norms evolve.  CVE-2019-6111 reflects this evolution in ssh, where the
+scp command had, until then, received files with whatever name the server
+provided, even if it wasn't requested by the client.  Since scp's default
+behavior was to overwrite files, this led to a vulnerability if the server was
+malicious.
+
+This parallels Kermit CVE-2025-68920, which applies to malicious servers
+attempting to perform actions on a local machine.  The scope of the initial fix
+to that was less than the ssh fix, however.  Further improvements to Kermit 11
+have closed the loop more; changing the file name collision policy, for
+instance.
+
 # Local/Remote Mode, ENABLE/DISABLE, and RECEIVE PATHNAMES
 
 This discussion is primarily about commands sent using the Kermit protocol.
@@ -44,7 +62,7 @@ on the local machine.  Think of it as the controller.  You want it to be able to
 control the remote, but not for the remote to be able to send Kermit commands to
 it (with some limited exceptions as I hinted above).
 
-Kermit is in local mode when it is the "far" end of the connection.  In that
+Kermit is in remote mode when it is the "far" end of the connection.  In that
 mode, it is being controlled by the local machine.
 
 So it follows that a Kermit in remote mode should allow a lot more kinds of


### PR DESCRIPTION
CK_WREFRESH was added in C-Kermit 5A(190) in 1994 in commit 609e2f390d13b170b319024c9063b240ab07bd35 and has had only some minor additions since.  It wasn't defined on Linux or MacOS back then and was never added later.  Mac OS X of course didn't exist then, and either Linux didn't define it or it was just overlooked.
    
The BSD44 case already catches all of the BSDs we build for.