### PR TITLE
Reinstate OpenVMS updates from C-Kermit 10.0 Beta 12

### DIFF
--- a/ckvbuildlog.com
+++ b/ckvbuildlog.com
@@ -1,0 +1,320 @@
+$!
+$! CKVBUILDLOG.COM - Record C-Kermit build info for OpenVMS
+$!
+$! P1: Output file spec.  Default: ckvblog.txt
+$!
+$! Usage:
+$!
+$!    $ set default build_dev:[build_dir]
+$!    $ @ source_dev:[source_dir]ckvbuildlog.com [ output_file_spec ]
+$!
+$!
+$ on error then goto clean_up
+$ say = "write sys$output"
+$!
+$! Script info.
+$!
+$ ckvbl_date = "2024-08-19"
+$ ckvbl_vers = "0.1"
+$!
+$! Determine the output file name.
+$!
+$ build_log_file_name = "ckvker.blog"
+$ out_file_name = "ckvblog.txt"
+$ shofeat_file_name = "shofeat.txt"
+$ wermit_exe = "sys$disk:[]wermit.exe"
+$!
+$ procedure = f$environment("PROCEDURE")
+$ procname = f$element(0,";",procedure)
+$ procname = f$parse( procname, , , "NAME", "SYNTAX_ONLY")+ -
+             f$parse( procname, , , "TYPE", "SYNTAX_ONLY")
+$!
+$ sts = 1
+$!
+$ if (P1 .nes. "")
+$ then
+$    out_file_name = P1
+$ endif
+$!
+$ if (f$search( wermit_exe) .eqs. "")
+$ then
+$   say "wermit executable (''wermit_exe') not found in this directory."
+$   say "This script (''procname') must be run in a C-Kermit build directory."
+$   say "Please see instructions in ""ckvker.com""."
+$   sts = %X00018292 ! RMS-E-FNF, file not found
+$   goto clean_up
+$ endif
+$!
+$! Open the output file.
+$!
+$ create /fdl = sys$input 'out_file_name'
+RECORD
+        FORMAT stream_lf
+$!
+$ open /append out_file 'out_file_name'
+$!
+$! Write the report.
+$!
+$! Prefix.
+$!
+$ write out_file "<tr>"
+$!
+$! OS, version.
+$!
+$ write out_file "<td>OpenVMS "+ f$getsyi( "version")
+$!
+$! Host architecture (from build log file).
+$!
+$ in_file_name = build_log_file_name
+$ search_string = "ARCH="
+$ gosub scanfile
+$ arch = f$extract( f$length( search_string), 2047, match)
+$ write out_file "<td>''arch'"
+$!
+$! Source location.
+$!
+$ in_file_name = build_log_file_name
+$ search_string = "CK_SOURCE="
+$ gosub scanfile
+$ ck_source = f$extract( f$length( search_string), 2047, match)
+$!
+$! Build command.
+$!
+$ in_file_name = build_log_file_name
+$ search_string = "P1="
+$ gosub scanfile
+$ bp1 = f$extract( f$length( search_string), 2047, match)
+$!
+$ search_string = "P2="
+$ gosub scanfile
+$ bp2 = f$extract( f$length( search_string), 2047, match)
+$!
+$ search_string = "P3="
+$ gosub scanfile
+$ bp3 = f$extract( f$length( search_string), 2047, match)
+$!
+$ search_string = "P4="
+$ gosub scanfile
+$ bp4 = f$extract( f$length( search_string), 2047, match)
+$!
+$ search_string = "P5="
+$ gosub scanfile
+$ bp5 = f$extract( f$length( search_string), 2047, match)
+$!
+$ search_string = "P6="
+$ gosub scanfile
+$ bp6 = f$extract( f$length( search_string), 2047, match)
+$!
+$ rp1 = ""
+$ rp2 = ""
+$ rp3 = ""
+$ rp4 = ""
+$ rp5 = ""
+$ rp6 = ""
+$!
+$ if ((bp1 .nes. "") .or. (bp2 .nes. "") .or. (bp3 .nes. "") .or. -
+      (bp4 .nes. "") .or. (bp5 .nes. "") .or. (bp6 .nes. ""))
+$ then
+$   rp1 = " """+ bp1+ """"
+$ endif
+$!
+$ if ((bp2 .nes. "") .or. (bp3 .nes. "") .or. -
+      (bp4 .nes. "") .or. (bp5 .nes. "") .or. (bp6 .nes. ""))
+$ then
+$   rp2 = " """+ bp2+ """"
+$ endif
+$!
+$ if ((bp3 .nes. "") .or. -
+      (bp4 .nes. "") .or. (bp5 .nes. "") .or. (bp6 .nes. ""))
+$ then
+$   rp3 = " """+ bp3+ """"
+$ endif
+$!
+$ if ((bp4 .nes. "") .or. (bp5 .nes. "") .or. (bp6 .nes. ""))
+$ then
+$   rp4 = " """+ bp4+ """"
+$ endif
+$!
+$ if ((bp5 .nes. "") .or. (bp6 .nes. ""))
+$ then
+$   rp5 = " """+ bp5+ """"
+$ endif
+$!
+$ if ((bp6 .nes. ""))
+$ then
+$   rp6 = " """+ bp6+ """"
+$ endif
+$!
+$ write out_file "<td>@ckvker.com"+  rp1+ rp2+ rp3+ rp4+ rp5+ rp6
+$!
+$! Source kit date.
+$!
+$ editndate = ""
+$ in_file_name = ck_source+ "ckcmai.c"
+$ search_string = "EDITNDATE"
+$ gosub scanfile
+$ sts = $status
+$ if (match .nes. "")
+$ then
+$   editndate = f$element( 2, " ", match)- """"- """" ! yyyymmdd
+$   editndate = f$extract( 0, 4, editndate)+ "-"+ -
+                f$extract( 4, 2, editndate)+ "-"+ -
+                f$extract( 6, 2, editndate)
+$ endif
+$ write out_file "<td>''editndate'"
+$!
+$! Executable (wermit.exe) size (bytes).
+$!
+$ if (f$parse( wermit_exe) .nes. "")
+$ then
+$   siz = f$file_attributes( wermit_exe, "EOF")* 512
+$ else
+$   siz = "???"
+$ endif
+$ write out_file "<td>''siz'"
+$!
+$! C compiler version.
+$!
+$ in_file_name = build_log_file_name
+$ search_string = "CC_VERSION="
+$ gosub scanfile
+$ ccv = f$extract( f$length( search_string), 2047, match)
+$ write out_file "<td>''ccv'"
+$!
+$! OpenSSL version.
+$!
+$ in_file_name = build_log_file_name
+$ search_string = "SSL_VERSION="
+$ gosub scanfile
+$ osslv = f$extract( f$length( search_string), 2047, match)
+$ write out_file "<td>''osslv'"
+$!
+$! "show features" report.
+$!
+$ ck_sts = 0
+$ banner = ""
+$ ck_dir = ""
+$ if (siz .nes. "???")
+$ then
+$!
+$! Note: With MCR anyplace, command-line case is not preserved.
+$! Upper-case (case-significant) command-line material must be quoted.
+$!
+$   define /user_mode sys$output 'shofeat_file_name'
+$   mcr 'wermit_exe' "-C" "{ show features, exit }"
+$   ck_sts = $status
+$!
+$   if ((ck_sts .and. %x7) .eq. 1)
+$   then
+$!
+$! Extract Kermit banner from "show features" report.
+$!
+$     in_file_name = shofeat_file_name
+$     search_string = "C-Kermit"
+$     gosub scanfile
+$     banner = match
+$!
+$! Extract Kermit "dir kermit.exe" report.
+$!
+$     temp_file_name = "ck_dir.tmp"
+$     define /user_mode sys$output 'temp_file_name'
+$     mcr 'wermit_exe' "-H" "-C" "dir wermit.exe , quit"
+$!
+$     in_file_name = temp_file_name
+$     search_string = "("
+$     gosub scanfile
+$     ck_dir = match
+$     delete /nolog 'temp_file_name';*
+$!
+$   endif
+$!
+$ endif
+$!
+$!
+$! Build Status.
+$!
+$ if ((ck_sts .and. %x7) .eq. 1)
+$ then
+$   sts_str = "OK"
+$ else
+$   sts_str = "FAILED"
+$ endif
+$ write out_file "<td>''sts_str'"
+$!
+$! Close the output file, if open.
+$!
+$ if (f$trnlnm( "out_file") .nes. "")
+$ then
+$   close out_file
+$ endif
+$!
+$! Display info.
+$!
+$ say "''procname' ''ckvbl_vers' ''ckvbl_date'"
+$ say "This directory: "+ f$environment( "default")
+$ if (banner .nes. "")
+$ then
+$   say "wermit: "+ banner
+$   say "Executable: "
+$   say ck_dir
+$   say ""
+$   say "''procname' done, result (also in ''out_file_name';"
+$   say "please email it to fdc@columbia.edu):"
+$   type 'out_file_name'
+$ else
+$   say "wermit.exe not found"
+$   say "''procname' must be run in a C-Kermit build directory."
+$   say "Please see instructions in ""ckvker.com""."
+$ endif
+$!
+$ clean_up:
+$!
+$ on error then exit
+$!
+$! Close the output file, if open.
+$!
+$ if (f$trnlnm( "out_file") .nes. "")
+$ then
+$   close out_file
+$ endif
+$!
+$! End of main-line code.
+$!
+$! Exit.
+$!
+$ exit 'sts'
+$!
+$!----------------------------------------------------------------------
+$!
+$! Subroutines.
+$!
+$! SCANFILE - Scan file 'in_file_name' for string 'search_string'.
+$             Return first matching line in symbol "match".
+$!
+$ scanfile:
+$!
+$! in_file_name: input file
+$! search_string: search string
+$! match: DCL symbol for output line
+$!
+$ open /read in_file 'in_file_name'
+$ sts = $status
+$ if ((sts .and. %x7) .eq. 1)
+$ then
+$   match = ""
+$   read_loop_top:
+$   read in_file line -
+     /end_of_file = read_loop_end /error = read_loop_end
+$!
+$   line_len = f$length( line)
+$   if (f$locate( search_string, line) .lt. line_len)
+$   then
+$     match = line
+$   else
+$     goto read_loop_top
+$   endif
+$   read_loop_end:
+$   close in_file
+$ endif
+$ return sts
+$!

--- a/ckvfio.c
+++ b/ckvfio.c
@@ -390,7 +390,7 @@ char *WHOCMD = "show users ";		/* For seeing who's logged in */
 char *PWDCMD = "show default ";		/* For seeing current directory */
 
 /*
-  Functions (n is one of the predefined file numbers from ckermi.h):
+  Functions (n is one of the predefined file numbers from ckcker.h):
 
    zopeni(n,name)   -- Opens an existing file for input.
    zopeno(n,name)   -- Opens a new file for output.
@@ -471,6 +471,9 @@ char *PWDCMD = "show default ";		/* For seeing current directory */
 
 #include <lnmdef.h>
 #include <rmsdef.h>
+
+#include "ckcnet.h"                     /* for struct sockaddr */
+#include "ckcfnp.h"                     /* Prototypes (must be last) */
 
 #ifndef MAXWLD
 #define MAXWLD 102400			/* Maximum wildcard filenames */
@@ -571,7 +574,7 @@ static unsigned long sub_pid;
  */
 
 static	struct FAB fab_ifile;		/* For SEND file */
-static	struct NAMX nam_ifile;
+static	struct NAMX_STRUCT nam_ifile;
 static	struct RAB rab_ifile;
 static	struct XABDAT xabdat_ifile;
 static	struct XABFHC xabfhc_ifile;
@@ -584,7 +587,7 @@ static	char aclbuf[512];
 static	unsigned long xuchar = 0;
 
 static	struct FAB fab_rfile;		/* For OPEN READ file */
-static	struct NAMX nam_rfile;
+static	struct NAMX_STRUCT nam_rfile;
 static	struct RAB rab_rfile;
 
 static	struct XABDAT xabdat_rfile;
@@ -601,7 +604,7 @@ static	char raclbuf[512];
  */
 
 static	struct FAB fab_ofile;
-static	struct NAMX nam_ofile;
+static	struct NAMX_STRUCT nam_ofile;
 static	struct RAB rab_ofile;
 static	struct XABDAT xabdat_ofile;
 static	struct XABFHC xabfhc_ofile;
@@ -625,7 +628,7 @@ static	short ofile_ffb;
  */
 
 static	struct FAB path_fab;
-static	struct NAMX path_nam;
+static	struct NAMX_STRUCT path_nam;
 static	char path_exp_name[ NAMX_C_MAXRSS];
 static	char path_res_name[ NAMX_C_MAXRSS];
 
@@ -789,7 +792,7 @@ int get_rms_defaults()
  *
  * 2010-03-22 SMS.
  * This would seem to be a somewhat fuzzy concept on VMS.  For example,
- * is "SYS$DISK:[]" not as relative as "[]"?  We say it's absolute.
+ * is "SYS$DISK:[]" not as relative as "[]"?  We say it's absolute. 
  * What about some other device, like, say, "DUA0:[]"?  We say it's
  * absolute.  Perhaps a check for a real logical name (with a directory
  * spec?) would be more realistic.
@@ -846,6 +849,45 @@ isabsolute(path) char * path; {
     return rc;
 }
 
+/* For the record, old VMS isabsolute() code from ckcmai.c. */
+#ifdef COMMENT
+
+/* Tell if a pathname is absolute (versus relative) */
+/* This should be parceled out to each of the ck*fio.c modules... */
+int
+isabsolute(path) char * path; {
+    int rc = 0;
+    int x;
+    if (!path)
+      return(0);
+    if (!*path)
+      return(0);
+    x = (int) strlen(path);
+    debug(F111,"isabsolute",path,x);
+#ifdef VMS
+    rc = 0;
+    x = ckindex("[",path,0,0,0);        /* 1-based */
+    if (!x)
+       x = ckindex("<",path,0,0,0);
+    debug(F111,"isabsolute left bracket",path,x);
+    if (!x) {
+        x = ckindex(":",path,-1,1,1);
+        if (x)
+          debug(F111,"isabsolute logical",path,x);
+    }
+    if (x > 0)
+      if (path[x] != '.')               /* 0-based */
+        rc = 1;
+#else
+[...]
+#endif /* VMS */
+    debug(F101,"isabsolute rc","",rc);
+    return(rc);
+}
+
+#endif /* def COMMENT */
+
+
 #ifdef CK_TMPDIR
 
 /*  I S D I R  --  Tells if string pointer s is the name of a directory. */
@@ -877,10 +919,7 @@ isdir(path) char *path; {
     path_fab.FAB_L_NAMX = &path_nam;            /* Point FAB to NAM[L]. */
 
     /* Install the path argument in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    path_fab.fab$l_dna = (char *) -1;   /* Using NAML for default name. */
-    path_fab.fab$l_fna = (char *) -1;   /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( path_fab)
     FAB_OR_NAML( path_fab, path_nam).FAB_OR_NAML_FNA = path;
     FAB_OR_NAML( path_fab, path_nam).FAB_OR_NAML_FNS = strlen( path);
 
@@ -1032,10 +1071,7 @@ iswild(path) char *path; {
     path_fab.FAB_L_NAMX = &path_nam;            /* Point FAB to NAM[L]. */
 
     /* Install the path argument in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    path_fab.fab$l_dna = (char *) -1;   /* Using NAML for default name. */
-    path_fab.fab$l_fna = (char *) -1;   /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( path_fab)
     FAB_OR_NAML( path_fab, path_nam).FAB_OR_NAML_FNA = path;
     FAB_OR_NAML( path_fab, path_nam).FAB_OR_NAML_FNS = strlen( path);
 
@@ -1147,10 +1183,7 @@ zopeni(n,name) int n; char *name; {
 	  fab_ifile.fab$b_fac = FAB$M_BIO | FAB$M_GET;
 
 	/* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-	fab_ifile.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-	fab_ifile.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+        NAMX_DNA_FNA_SET( fab_ifile)
 	FAB_OR_NAML( fab_ifile, nam_ifile).FAB_OR_NAML_FNA = name;
 	FAB_OR_NAML( fab_ifile, nam_ifile).FAB_OR_NAML_FNS = strlen( name);
 
@@ -1199,7 +1232,7 @@ zopeni(n,name) int n; char *name; {
 		debug(F100,"zopeni fixed file format - using blk I/O","",0);
 		ifile_bmode = 1;
 	    }
-	}
+  	}
 	debug(F101,"zopeni binary flag at open","",binary);
 	if (binary == XYFT_I) {
 	    debug(F100,"zopeni using IMAGE mode by user request","",0);
@@ -1231,7 +1264,7 @@ zopeni(n,name) int n; char *name; {
 	    /* (but only for odd-record length fixed-block files) */
 
 	    debug(F100,"zopeni record i/o for BINARY, Odd Fixed RL","",0);
-	}
+      	}
 	rab_ifile.rab$l_rop = 0;
 	rms_sts = sys$connect(&rab_ifile);
 	if (!(rms_sts & 1)) vms_lasterr = rms_sts;
@@ -1256,10 +1289,7 @@ zopeni(n,name) int n; char *name; {
 	fab_rfile.fab$b_fac = FAB$M_BRO | FAB$M_GET;
 
 	/* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-	fab_rfile.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-	fab_rfile.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+        NAMX_DNA_FNA_SET( fab_rfile)
 	FAB_OR_NAML( fab_rfile, nam_rfile).FAB_OR_NAML_FNA = name;
 	FAB_OR_NAML( fab_rfile, nam_rfile).FAB_OR_NAML_FNS = strlen( name);
 
@@ -1310,7 +1340,7 @@ zopeni(n,name) int n; char *name; {
 		debug(F100,"zopeni ZRFILE fixed file format - fail","",0);
 		return(0);
 	    }
-	}
+  	}
 	rab_rfile.rab$l_rop = 0;
 	rms_sts = sys$connect(&rab_rfile);
 	if (!(rms_sts & 1)) vms_lasterr = rms_sts;
@@ -1386,31 +1416,42 @@ zopeno(n,name,zz,fcb)
 	}
 
 /* Note: don't add "ctx=rec", "shr=get" here - it slows writes to a crawl */
+/* 2024-04-23 SMS.  Get text-file record format from SET VMS_TEXT. */
 
-	if (n != ZSFILE) {
-	    /* was mrs = 80; 254 is max record size for EDT */
-	    fp[n] = fopen(name, p, "rat=cr", "rfm=var", "mrs=254");
-	} else {			/* Session Log */
-	    extern int sessft;		/* Type */
+	extern int vms_text;        /* VMS record format for text files. */
+	if (n == ZSFILE) {		/* Session Log */
+	    extern int sessft;		/* Type (binary/text) */
+
 	    if (sessft == XYFT_T) {	/* Text */
-		fp[n] = fopen(name, p, "ctx=stm", "rat=cr", "rfm=stmlf");
+	        if (vms_text == VMSTFV) { /* Variable-length. */
+		    fp[n] = fopen(name, p, "rat=cr", "rfm=var");
+	        } else {		  /* Stream_LF (default). */
+		    fp[n] = fopen(name, p, "ctx=stm", "rat=cr", "rfm=stmlf");
+	        }
 	    } else {			/* Binary */
 		fp[n] = fopen(name, p, "ctx=bin", "rat=none",
-			               "rfm=fix", "mrs=512");
+		                       "rfm=fix", "mrs=512");
+	    }
+	} else {			/* Not session Log. */
+	    if (vms_text == VMSTFV) {	  /* Variable-length. */
+		/* was mrs = 80; 254 is max record size for EDT */
+		fp[n] = fopen(name, p, "rat=cr", "rfm=var", "mrs=254");
+	    } else {			  /* Stream_LF (default). */
+		fp[n] = fopen(name, p, "ctx=stm", "rat=cr", "rfm=stmlf");
 	    }
 	}
 	if (fp[n] == NULL) {		/* Failed */
-            if (errno == EVMSERR) {
+	    if (errno == EVMSERR) {
 	        debug(F111,"zopeno fopen failed vaxc$errno",name,vaxc$errno);
-                if (vaxc$errno == RMS$_SYN)
-                  printf("?fopen file name syntax error : %s\n", name);
-                else
-                  printf("?fopen failed %s : %s\n",name,
-                         ckvmserrstr(vaxc$errno));
-            } else {
-	        debug(F111,"zopeno fopen failed errno",name,errno);
-                perror(name);
-            }
+		if (vaxc$errno == RMS$_SYN)
+		    printf("?fopen file name syntax error : %s\n", name);
+		else
+		    printf("?fopen failed %s : %s\n",name,
+		    ckvmserrstr(vaxc$errno));
+	    } else {
+		debug(F111,"zopeno fopen failed errno",name,errno);
+		perror(name);
+	    }
 	} else {			/* Didn't fail */
 	    debug(F100,"zopeno fopen ok", "", 0);
 	}
@@ -1454,10 +1495,7 @@ zopeno(n,name,zz,fcb)
 	fab_ofile.FAB_L_NAMX = &nam_ofile;      /* Point FAB to NAM[L]. */
 
 	/* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-	fab_ofile.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-	fab_ofile.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+        NAMX_DNA_FNA_SET( fab_ofile)
 	FAB_OR_NAML( fab_ofile, nam_ofile).FAB_OR_NAML_FNA = name;
 	FAB_OR_NAML( fab_ofile, nam_ofile).FAB_OR_NAML_FNS = strlen( name);
 
@@ -2444,7 +2482,7 @@ zchout(n,c) register int n; char c;
     if (chkfn(n) < 1) return(-1);
 #endif
     if (n == ZSFILE) {
-	return(write(fileno(fp[n]),&c,1)); /* Use unbuffered for session log */
+    	return(write(fileno(fp[n]),&c,1)); /* Use unbuffered for session log */
     } else {
 	if (putc(c,fp[n]) == EOF)	/* If true, maybe there was an error */
 	  return(ferror(fp[n]) ? -1 : 0); /* Check to make sure */
@@ -2732,7 +2770,7 @@ zchki(name) char *name; {
     extern int zchkid;
     int x;
     struct FAB fab_chki;
-    struct NAMX nam_chki;
+    struct NAMX_STRUCT nam_chki;
     struct XABFHC xabfhc_chki;
     CK_OFF_T iflen = (CK_OFF_T)-1;
 
@@ -2763,10 +2801,7 @@ zchki(name) char *name; {
     fab_chki.FAB_L_NAMX = &nam_chki;            /* Point FAB to NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab_chki.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab_chki.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab_chki)
     FAB_OR_NAML( fab_chki, nam_chki).FAB_OR_NAML_FNA = name;
     FAB_OR_NAML( fab_chki, nam_chki).FAB_OR_NAML_FNS = strlen( name);
 
@@ -2806,7 +2841,7 @@ zchko(name) char *name; {
     extern int zchkod;                  /* Used by IF WRITEABLE */
 
     struct FAB fab;			/* let RMS do the work */
-    struct NAMX nam;
+    struct NAMX_STRUCT nam;
     char expanded_str[NAMX_C_MAXRSS+ 1];
 
     if (!name) return(-1);              /* Watch out for null pointer. */
@@ -2817,10 +2852,7 @@ zchko(name) char *name; {
     fab.FAB_L_NAMX = &nam;              /* Point FAB to NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab)
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNA = name;
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNS = strlen( name);
 
@@ -3095,7 +3127,7 @@ nzrtol(name,name2,fncnv,fnrpath,max)
         np = name + start;		/* ptr to name in tmpbuf */
         bb = tmpbuf;			/* destination */
 	if (tmpbuf[0] == '[') {		/* [179] If it starts with a bracket */
-	    *bb++ = *np++;
+	    *bb++ = *np++;		
 	    if (*np != '.')
 	      *bb++ = '.';		/* make relative */
 	}
@@ -3251,7 +3283,7 @@ nzltor(name,name2,fncnv,fnspath,cp_len)
     char *cp, *pp;
     int flag;
     struct FAB fab;
-    struct NAMX nam;
+    struct NAMX_STRUCT nam;
     char expanded_name[ NAMX_C_MAXRSS];
     char dirbuf[ NAMX_C_MAXRSS], *p, *q, *q2, *r, *s, *s2;
     int long rms_status;
@@ -3272,10 +3304,7 @@ nzltor(name,name2,fncnv,fnspath,cp_len)
     fab.FAB_L_NAMX = &nam;              /* Point FAB to NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab)
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNA = name;
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNS = strlen( name);
 
@@ -3934,7 +3963,7 @@ zxcmd(filnum, comand) int filnum; char *comand; {
     if (sts != SS$_NORMAL)
       return(0);
 
-    sprintf(mbxnam,"KERMIT$MBX_%08X", (unsigned int)pid);
+    sprintf(mbxnam,"KERMIT$MBX_%08X", pid);
     debug(F110,"zxcmd mailbox logical", mbxnam, 0);
     mbx_desc.dsc$w_length = strlen(mbxnam);
     mbx_desc.dsc$a_pointer = mbxnam;
@@ -4170,7 +4199,7 @@ zfnqfp(fn, buflen, buf)  char * fn; int buflen; char * buf; {
     static struct zfnfp fnfp;
 
     struct FAB fab;
-    struct NAMX nam;
+    struct NAMX_STRUCT nam;
     char expanded_name[NAMX_C_MAXRSS];
     char tmpnam[NAMX_C_MAXRSS+ 16];
     int long rms_status;
@@ -4207,10 +4236,7 @@ zfnqfp(fn, buflen, buf)  char * fn; int buflen; char * buf; {
     fab.FAB_L_NAMX = &nam;              /* Point the FAB to the NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab)
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNA = cp;
     FAB_OR_NAML( fab, nam).FAB_OR_NAML_FNS = strlen( cp);
 
@@ -4680,8 +4706,7 @@ zstime(f,yy,x) char *f; struct zattr *yy; int x; {
 	return(-1);
     }
     debug(F110,"zstime built",cdate,0);
-    sprintf(cdate, "%08X%08X",
-	    (unsigned int)attr_date[1], (unsigned int)attr_date[0]);
+    sprintf(cdate, "%08X%08X", attr_date[1], attr_date[0]);
     debug(F110,"zstime $bintim attr_date", cdate, 0);
     setdate = 1;
 
@@ -4736,11 +4761,11 @@ zstime(f,yy,x) char *f; struct zattr *yy; int x; {
 	    unsigned long dfpro = 0L, mask = 0L;
 	    unsigned short tmp;
 	    tmp = xabpro_ofile.xab$w_pro;
-	    rms_sts = sys$setdfprot(0,&dfpro); /* Get default protection */
+    	    rms_sts = sys$setdfprot(0,&dfpro); /* Get default protection */
 	    if (!(rms_sts & 1)) vms_lasterr = rms_sts;
 #ifdef DEBUG
 	    if (deblog) {
-		sprintf(xbuf,"%X",(unsigned int)dfpro);
+		sprintf(xbuf,"%X",dfpro);
 		debug(F111,"zstime sys$setdfprot",xbuf,rms_sts);
 	    }
 #endif /* DEBUG */
@@ -4793,10 +4818,7 @@ zstime(f,yy,x) char *f; struct zattr *yy; int x; {
 	fab_ifile.FAB_L_NAMX = &nam_ifile;  /* Point the FAB to the NAM[L]. */
 
 	/* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-	fab_ifile.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-	fab_ifile.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+        NAMX_DNA_FNA_SET( fab_ifile)
 	FAB_OR_NAML( fab_ifile, nam_ifile).FAB_OR_NAML_FNA = f;
 	FAB_OR_NAML( fab_ifile, nam_ifile).FAB_OR_NAML_FNS = strlen( f);
 
@@ -4812,8 +4834,7 @@ zstime(f,yy,x) char *f; struct zattr *yy; int x; {
 	    return(-1);
 	}
 	memcpy(file_date, &xabdat_ifile.xab$q_cdt, 8);
-	sprintf(cdate, "%08x%08x",
-		(unsigned int)file_date[1], (unsigned int)file_date[0]);
+	sprintf(cdate, "%08x%08x", file_date[1], file_date[0]);
 	debug(F110,"zstime $bintim file_date", cdate, 0);
 	rms_sts = sys$close(&fab_ifile);
 	if (!(rms_sts & 1)) vms_lasterr = rms_sts;
@@ -4938,6 +4959,160 @@ zkermini(s, s_len, def) char *s; int s_len; char *def; {
     return(0);
 }
 
+#ifdef COMMENT
+static int
+parse_fname(cp, cp_len, defnam, flag, fncnv, fnspath)
+char *cp;		/* Pointer to file spec to parse */
+int cp_len;		/* Length of cp field */
+char *defnam;		/* Default file spec */
+int flag;		/* Flag word PARSE_xxx */
+int fncnv;		/* Filename conversion */
+int fnspath;		/* Pathname handling */
+{
+    struct FAB fab;
+    struct NAM nam;
+    char expanded_name[ NAMX_C_MAXRSS];
+    char dirbuf[ NAMX_C_MAXRSS], *p, *q, *q2, *r, *s, *s2;
+    int long rms_status;
+    int cur_len = 0;
+
+    debug(F110,"zltor entry",defnam,0);
+
+    fab = cc$rms_fab;
+    fab.fab$l_nam = &nam;
+    fab.fab$l_fna = cp;
+    fab.fab$b_fns = strlen(cp);
+    if (defnam) {
+	fab.fab$b_dns = strlen(defnam);
+	fab.fab$l_dna = defnam;
+    } else
+      fab.fab$l_dna = 0;
+
+    nam = cc$rms_nam;
+    nam.nam$l_esa = (char *)&expanded_name;
+    nam.nam$b_ess = sizeof(expanded_name);
+
+    if (!CHECK_ERR("%%CKERMIT-W-PARSE, ",
+		sys$parse(&fab)))
+	return(-1);
+
+    *cp = '\0';				/* Start with an empty result */
+
+    if ((PARSE_NODE & flag) && nam.nam$b_node && /* DECnet node:: */
+		cur_len+nam.nam$b_node < cp_len) {
+	cur_len += nam.nam$b_node;
+	strncat(cp, nam.nam$l_node, (int)nam.nam$b_node);
+    }
+    if ((PARSE_DEVICE & flag) && nam.nam$b_dev && /* Device: */
+		cur_len+nam.nam$b_dev < cp_len) {
+	cur_len += nam.nam$b_dev;
+	strncat(cp, nam.nam$l_dev, (int)nam.nam$b_dev);
+    }
+
+    /* Directory Name [] */
+
+    if ((PARSE_DIRECTORY & flag) && nam.nam$b_dir &&
+		cur_len+nam.nam$b_dir < cp_len) {
+	int i; char * tmp;
+        q = nam.nam$l_dir;		/* The directory name from RMS */
+	i = nam.nam$b_dir;		/* Length; string not nul-terminated */
+	debug(F111,"zltor nam$_dir",q,i);
+	if (!q) q = "[]";
+	if (!*q) q = "[]";
+	if (i < 0) i = 0;
+	tmp = NULL;
+	if (i > 0) {			/* Copy directory part */
+	    if (tmp = malloc(i+1)) {
+		p = tmp;
+		for ( ; i > 0 ; i--)
+		  *p++ = *q++;
+		*p = NUL;
+	    }
+	}
+	q = tmp;
+	debug(F111,"zltor directory part",q,i);
+
+	s = zgtdir();			/* Get current directory */
+	debug(F110,"zltor zgtdir",s,0);
+	if (!s) s = "[]";
+	if (!*s) s = "[]";
+	s2 = "";
+	while (*s && *s != '[')
+	  s++;
+	if (*s) {
+	    s2 = s+1;
+	    while (*s2 && *s2 != ']') s2++; /* Closing bracket */
+	}
+	if (!*s)
+	  s = "[]";
+	else
+	  if (*s2) if (!*(s2+1)) *(s2+1) = NUL;
+	debug(F110,"zltor current dir",s,0);
+
+/* First change the VMS pathname to relative format if fnspath == PATH_REL */
+
+	p = dirbuf;			/* Result */
+	*p++ = *q++;			/* Copy left bracket and... */
+
+	s++;				/* Point past it */
+	q2 = q;				/* Remember this place */
+	if (fnspath == PATH_REL) {	/* Compare this and current dir */
+	    while (*s == *q && *s && *q && *s != ']') {
+		s++;
+		q++;
+	    }
+	}
+	if (*s != ']' && *q != ']' && *q != '.') /* No match */
+	  q = q2;			/* So rewind source pointer */
+
+	while (*q) *p++ = *q++;		/* Now copy the rest */
+	*p = NUL;
+	debug(F110,"zltor result 1",dirbuf,0);
+/*
+   VMS directory name is now in dirbuf in either absolute or relative format.
+   Now change it to standard (UNIX) format if desired.
+*/
+	p = dirbuf;			/* Working pointer */
+	r = dirbuf;			/* Result pointer */
+	if (fncnv) {			/* Converting directory format */
+	    int flag = 0;
+	    if (p[1] == '.') {		/* Directory name is relative */
+		r += 2;			/* Point past the leading dot */
+		p += 2;
+	    }
+	    while (*p) {		/* Now convert the rest */
+		if (*p == '.' || *p == '[' || *p == ']') {
+		    if (!flag) *p = '/';
+		    if (*p == ']')
+		      flag = 1;
+		}
+		p++;
+	    }
+	}
+	debug(F110,"zltor result 2",r,0);
+	if (tmp) free(tmp);
+	strncat(cp, r, (int)nam.nam$b_dir);
+	cur_len += strlen(r);
+    }
+    if ((PARSE_NAME & flag) && nam.nam$b_name &&
+		cur_len+nam.nam$b_name < cp_len) {
+	cur_len += nam.nam$b_name;
+	strncat(cp, nam.nam$l_name, (int)nam.nam$b_name);
+    }
+    if ((PARSE_TYPE & flag) && nam.nam$b_type &&
+		cur_len+nam.nam$b_type < cp_len) {
+	cur_len += nam.nam$b_type;
+	strncat(cp, nam.nam$l_type, (int)nam.nam$b_type);
+    }
+    if ((PARSE_VERSION & flag) && nam.nam$b_ver &&
+		cur_len+nam.nam$b_ver < cp_len) {
+	cur_len += nam.nam$b_ver;
+	strncat(cp, nam.nam$l_ver, (int)nam.nam$b_ver);
+    }
+    return(cur_len);
+}
+#endif /* COMMENT */
+
 /* Z G P E R M  --  Returns the permissions (protection) of the given file. */
 
 static char zgpbuf[24];
@@ -4946,7 +5121,7 @@ char *
 zgperm(f) char *f; {
     int x, x1, x2, x3, x4;
     struct FAB fab_perm;
-    struct NAMX nam_perm;
+    struct NAMX_STRUCT nam_perm;
     struct XABFHC xabfhc_perm;
     struct XABPRO xabpro_perm;
     struct XABDAT xabdat_perm;
@@ -4957,10 +5132,7 @@ zgperm(f) char *f; {
     fab_perm.FAB_L_NAMX = &nam_perm;    /* Point the FAB to the NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab_perm.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab_perm.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab_perm)
     FAB_OR_NAML( fab_perm, nam_perm).FAB_OR_NAML_FNA = f;
     FAB_OR_NAML( fab_perm, nam_perm).FAB_OR_NAML_FNS = strlen( f);
 
@@ -5234,7 +5406,7 @@ zsattr(xx) struct zattr *xx; {
 int
 zmkdir(path) char *path; {
     struct FAB dir_fab;
-    struct NAMX dir_nam;
+    struct NAMX_STRUCT dir_nam;
     struct dsc$descriptor_s expanded_filename;
 
     char expanded_name[ NAMX_C_MAXRSS];
@@ -5244,10 +5416,7 @@ zmkdir(path) char *path; {
     dir_fab.FAB_L_NAMX = &dir_nam;      /* Point the FAB to the NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    dir_fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    dir_fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( dir_fab)
     FAB_OR_NAML( dir_fab, dir_nam).FAB_OR_NAML_FNA = path;
     FAB_OR_NAML( dir_fab, dir_nam).FAB_OR_NAML_FNS = strlen( path);
 
@@ -5306,7 +5475,7 @@ zrmdir(path) char *path; {
     char *dir_end;
     char *dot_last;
     struct FAB fab_dir;
-    struct NAMX nam_dir;
+    struct NAMX_STRUCT nam_dir;
     char exp_name[ NAMX_C_MAXRSS];
     char dir_name[ NAMX_C_MAXRSS];
 
@@ -5386,10 +5555,7 @@ zrmdir(path) char *path; {
     fab_dir.FAB_L_NAMX = &nam_dir;      /* Point the FAB to the NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    fab_dir.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    fab_dir.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( fab_dir)
     FAB_OR_NAML( fab_dir, nam_dir).FAB_OR_NAML_FNA = path;
     FAB_OR_NAML( fab_dir, nam_dir).FAB_OR_NAML_FNS = strlen( path);
 
@@ -5490,10 +5656,8 @@ zrmdir(path) char *path; {
         fab_dir.FAB_L_NAMX = &nam_dir;  /* Point the FAB to the NAM[L]. */
 
         /* Install the path name in the FAB or NAML. */
+        NAMX_DNA_FNA_SET( fab_dir)
 #ifdef NAML$C_MAXRSS
-        fab_dir.fab$l_dna = (char *) -1;    /* Using NAML for default name. */
-        fab_dir.fab$l_fna = (char *) -1;    /* Using NAML for file name. */
-
         /* Special ODS5-QIO-compatible name storage. */
         nam_dir.naml$l_filesys_name = sys_name;
         nam_dir.naml$l_filesys_name_alloc = sizeof( sys_name);
@@ -5736,7 +5900,7 @@ zshcmd(s) char *s; {
     if (i != NULL) {
         debug(F100,"zshcmd: spawn prohibited on remote node","",0);
         printf("Cannot SPAWN with remote node as default directory\n");
-	if (*s)
+ 	if (*s)
 	  printf("therefore, cannot execute the DCL command \"%s\"\n", s);
         return(0);
     }
@@ -5797,7 +5961,7 @@ zstrip(name,name2) char *name, **name2; {
 
     for (cp = name; *cp; cp++) {
 	last = *cp;
-	if (*cp == '/' || *cp == ':' || *cp == '>' || *cp == ']') /* slash? */
+    	if (*cp == '/' || *cp == ':' || *cp == '>' || *cp == ']') /* slash? */
 	  pp = work;
 	else if (*cp == ';')		/* Chop off any version number */
 	  break;
@@ -5898,7 +6062,7 @@ zchkpath(s) char *s; {
  */
     unsigned int dd_len, status;
     struct FAB my_fab;
-    struct NAMX dd_nam, s_nam;
+    struct NAMX_STRUCT dd_nam, s_nam;
     const char *default_dir = "dummy.name";	/* guaranteed to resolve to */
 						/* the current default dir. */
     char dd_expanded_name[ NAMX_C_MAXRSS];
@@ -5909,10 +6073,7 @@ zchkpath(s) char *s; {
     my_fab.FAB_L_NAMX = &dd_nam;        /* Point the FAB to the NAM[L]. */
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    my_fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    my_fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( my_fab)
     FAB_OR_NAML( my_fab, dd_nam).FAB_OR_NAML_FNA = (char *)default_dir;
     FAB_OR_NAML( my_fab, dd_nam).FAB_OR_NAML_FNS = strlen( default_dir);
 
@@ -5932,10 +6093,7 @@ zchkpath(s) char *s; {
     my_fab.FAB_L_NAMX = &s_nam;
 
     /* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-    my_fab.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-    my_fab.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+    NAMX_DNA_FNA_SET( my_fab)
     FAB_OR_NAML( my_fab, s_nam).FAB_OR_NAML_FNA = s;
     FAB_OR_NAML( my_fab, s_nam).FAB_OR_NAML_FNS = strlen( s);
 
@@ -6129,7 +6287,7 @@ do_label_send(name) char *name; {
     if (fnspath == PATH_REL) {
         rel_dspec = fnd_rel(name);
         debug(F101," do_label_send: rel dir at char","", rel_dspec);
-        zp += sprintf(zp,"07REL_DIR00000008%08ld", (long)rel_dspec);
+        zp += sprintf(zp,"07REL_DIR00000008%08ld", rel_dspec);
     }
     zp += sprintf(zp,"07VMSNAME%08d", strlen(name));
     zp += sprintf(zp,"%s", name);
@@ -6417,10 +6575,7 @@ do_label_recv() {
 
     if ((ofile_lblopts & LBL_NAM) != 0) {
 	/* Install the path name in the FAB or NAML. */
-#ifdef NAML$C_MAXRSS
-	fab_ofile.fab$l_dna = (char *) -1;  /* Using NAML for default name. */
-	fab_ofile.fab$l_fna = (char *) -1;  /* Using NAML for file name. */
-#endif /* def NAML$C_MAXRSS */
+        NAMX_DNA_FNA_SET( fab_ofile)
 	FAB_OR_NAML( fab_ofile, nam_ofile).FAB_OR_NAML_FNA = ofile_vmsname;
 	FAB_OR_NAML( fab_ofile, nam_ofile).FAB_OR_NAML_FNS =
 	 strlen( ofile_vmsname);
@@ -6572,6 +6727,64 @@ ckvmserrstr(x) unsigned long x; {
     return((char *)xxvmsmsg);
 }
 
+/*----------------------------------------------------------------------
+ *
+ *       getexedir()
+ *
+ *   Extract the directory spec for the Kermit executable from xarg0
+ *   (copy of argv[ 0]).
+ *
+ * As of 2023-06-26, no header file provides the prototype for
+ * getexedir().  (Or a declaration for exedir or xarg0).
+ *
+/*--------------------------------------------------------------------*/
+
+_PROTOTYP( VOID getexedir, (void) );
+
+VOID
+getexedir( void)
+{
+  extern char *xarg0;
+  extern char *exedir;
+
+  int sts;
+
+/* RMS structures, buffers used for file parsing. */
+
+  struct FAB fab_exe;                   /* File Access Block. */
+  struct NAMX_STRUCT exe_nam;           /* [Long] Name Block. */
+  char exp_nam[ NAMX_C_MAXRSS+ 1];      /* Expanded String Area. */
+
+  /* Initialize the FAB and NAM[L], and link the NAM[L] to the FAB. */
+  fab_exe = cc$rms_fab;
+  exe_nam = CC_RMS_NAMX;
+  fab_exe.FAB_L_NAMX = &exe_nam;
+
+  /* Point the FAB/NAM[L] fields to the actual file spec. */
+
+  NAMX_DNA_FNA_SET( fab_exe)
+  FAB_OR_NAML( fab_exe, exe_nam).FAB_OR_NAML_FNA = xarg0;
+  FAB_OR_NAML( fab_exe, exe_nam).FAB_OR_NAML_FNS = strlen( xarg0);
+
+  exe_nam.NAMX_L_ESA = exp_nam;
+  exe_nam.NAMX_B_ESL = 0;
+  exe_nam.NAMX_B_ESS = sizeof( exp_nam)- 1;
+
+/* Parse the file specification. */
+
+  sts = sys$parse( &fab_exe, 0, 0);     /* Can't fail? */
+
+  /* NUL-terminate at the beginning of the name (end-of-dir+ 1). */
+  *exe_nam.NAMX_L_NAME = '\0';
+
+  if ((sts& STS$M_SEVERITY) == STS$K_SUCCESS)
+  {
+    makestr( &exedir, exp_nam);         /* Save the result. */
+  }
+}
+
+/*--------------------------------------------------------------------*/
+
 /* End of CKVFIO.C */
 
 
@@ -6701,11 +6914,11 @@ isdir(s) char *s; {
     while (i >= 0 && s[i] != ':') i--;
 
     if (i >= 0 && s[i] == ':') {
-	if (i == 0) return(0);		/* Single colon (:) */
-	if (s[i-1] == ':') {
-	    if (i > 1) return(1);	/* DECnet node name (blah::) */
-	    else return(0);		/* or :: alone. */
-	}
+    	if (i == 0) return(0);		/* Single colon (:) */
+    	if (s[i-1] == ':') {
+    	    if (i > 1) return(1);	/* DECnet node name (blah::) */
+    	    else return(0);		/* or :: alone. */
+    	}
 	s_len = i;
 	full_name = malloc(s_len + 1);
 	if (!full_name) return(0);
@@ -6761,9 +6974,9 @@ isdir(s) char *s; {
 	    if (new_len > 2 &&
 	        (name_buf[new_len-1] == ']' || name_buf[new_len-1] == '>') &&
 	        name_buf[new_len-2] == '.') {
-		/* Remove trailing dot in directory of logical name */
-		name_buf[new_len-2] = name_buf[new_len-1];
-		name_buf[new_len-1] = '\0';
+	    	/* Remove trailing dot in directory of logical name */
+	    	name_buf[new_len-2] = name_buf[new_len-1];
+	    	name_buf[new_len-1] = '\0';
 	    }
 	    free(full_name);
 	    return( isdir(name_buf) );

--- a/ckvker.com
+++ b/ckvker.com
@@ -1,10 +1,15 @@
 $!
-$! CKVKER.COM - C-Kermit 9.0 Construction for (Open)VMS
+$! CKVKER.COM - C-Kermit 9.0-11.0 Construction for (Open)VMS
 $!
-$! Version 1.48+sms, 15-Nov-2022
+$! Version 1.50, 2025-08-04
 $!
 $! DCL usage requires VMS 5.0 or higher - use CKVOLD.COM for VMS 4.x.
 $!
+$ p1o = p1 ! Save with original case, content.
+$ p2o = p2
+$ p3o = p3
+$ p5o = p5
+$ 
 $ p1 = f$edit( p1, "UPCASE")
 $ p1_len  = f$length( p1)
 $! Provide help if P1 includes "H" or "?".
@@ -17,7 +22,7 @@ $!
 $Help:
 $type sys$input
    Usage:
-       $ @[directory]ckvker [ p1 [ p2 [ p3 [ p4 [ p5 ] ] ] ] ]
+       $ @[directory]ckvker [ p1 [ p2 [ p3 [ p4 [ p5 [ p6 ] ] ] ] ] ]
 
        P1 = Build options
        P2 = Compiler selection
@@ -37,7 +42,8 @@ $type sys$input
        D = compile and link /DEBUG  (Create map files, etc.)
        F = DISABLE large-file support  (See LARGE_FILE NOTES below.)
        H = display help message
-       I = DISABLE internal FTP (it's enabled by default in network builds)
+       I = DISABLE internal FTP (enabled by default in network builds)
+       J = DISABLE internal HTTP (enabled by default in network builds)
        L = RTL version level -- link with latest math RTL
        M = don't use MMS or MMK; use the DCL MAKE subroutine herein
        N = build with no network support
@@ -60,14 +66,17 @@ $type sys$input
                    options, and other parameters follow.
           BUGFILL7 If you get %CC-E-NEEDMEMBER, '"xab$b_bkz" is not a member
                    of "xaball_ofile"'.  (Effectively implies NOCONVROUTINES.)
-          CK_SSL   includes SSL/TLS support for secure connections.  OpenSSL
-          CKSSL111 logical names will override vendor-supplied SSL kit.
-                   As of Kermit version 9.0.305 (or so), OpenSSL 1.1.1 (or
-                   later) is required, so logical names like OSSL$INCLUDE
-                   (OpenSSL), or SSL111$INCLUDE or SSL3$INCLUDE (VSI SSL),
-                   will be used, with VSI SSL3 preferred over VSI SSL111 if
-                   both are installed.  Specify CK_SSL111 to use VSI SSL111
-                   if VSI SSL3 is also installed.
+          CK_SSL[=vrsn]  includes SSL/TLS support for secure connections.
+                         Optional "=vrsn" argument specifies the version
+                   of vendor SSL to use (using logical names like): 
+                     CK_SSL=111  SSL111  (SSL111$INCLUDE)
+                     CK_SSL=3    SSL3    (SSL3$INCLUDE)
+                     CK_SSL=31   SSL31   (SSL31$INCLUDE), and so on.
+                   If "=vrsn" is not specified, the following SSL kits will
+                   be tried (in this order):
+                     User-built OpenSSL  (OSSL$INCLUDE)
+                     Vendor SSL3         (SSL3$INCLUDE)
+                     Vendor SSL111       (SSL111$INCLUDE)
           CK_SSL0  Do not define C macro OPENSSL_100 (generally unwise).
           INTSELECT If you get %CC-W-PTRMISMATCH on statements with select().
           NEEDUINT If you get complaints about "u_int" not defined (TCPware5.4)
@@ -378,6 +387,14 @@ $!                    IA64-to-x86_64 cross tools can be made to work.
 $! 01-Sep-22 1.48+sms Added definition of C macro OPENSSL_100, unless
 $!                    user specifies CK_SSL0 in P3.
 $! 15-Nov-22 1.48+sms Removed CKWART.C, et al.
+$! 07-Jun-24 1.48+sms Added P1 option J (internal_http).  CKHTTP was never
+$!                    being defined, but compile and link may work now.
+$!                    Could enable in ckcdeb.h for VMS, too, but comments
+$!                    suggest VMS version dependence, best handled here?
+$!                    Added optional "=vrsn" argument to P3 option CK_SSL.
+$! 26-Mar-25 1.49     Restored CKWART.C, et al.
+$! 04-Aug-25 1.50     For IPv6 under DEC_TCPIP need to link against
+$!                    tcp$library:tcp$lib.olb for ip5addr_any symbol
 $!
 $Skip_Help:
 $!
@@ -396,11 +413,13 @@ $ endif
 $ save_verify_image = f$environment( "VERIFY_IMAGE")
 $ save_verify_procedure = f$verify( ck_verify)
 $!
-$ say == "Write sys$output"
+$ say = "Write sys$output"
 $ procedure = f$environment("PROCEDURE")
 $ procname = f$element(0,";",procedure)
+$ procbasename = f$parse( procname, , , "NAME", "SYNTAX_ONLY")
 $ node = f$getsyi("NODENAME")
 $ say "Starting ''procedure' on ''node' at ''f$time()'"
+$ cc_version = "???"
 $ ccopt = ""
 $ lopt = ""
 $ make = ""
@@ -424,10 +443,11 @@ $ nomms=0
 $ mmsclm=264        ! maximum command length limit for MMS/MMK (estimate)
 $ do_ckvcvt=0
 $ ssl=0             ! SSL support disabled by default.
-$ ssl111=0          ! Use vendor SSL 1.1.1 when vendor SSL 3 is available.
 $ sslolb=0          ! SSL uses shared images by default.
+$ ssl_version=""    ! SSL version.
 $ openssl_def = 0   ! Redefined OPENSSL process logical name.
 $ internal_ftp=1    ! FTP client enabled by default.
+$ internal_http=1   ! HTTP client enabled by default.
 $ large_file=1      ! Large file support enabled by default.
 $!
 $ if (f$type( cc) .eqs. "")
@@ -483,11 +503,11 @@ $ if f$trnlnm("CK_SOURCE") .eqs. ""
 $ then
 $   source_device = f$parse(f$environment("procedure"),,,"device")
 $   source_directory = f$parse(f$environment("procedure"),,,"directory")
-$   define K 'source_device''source_directory
+$   ck_source = source_device+ source_directory
 $ else
-$   user_source = f$trnlnm("CK_SOURCE")
-$   define K 'user_source'
+$   ck_source = f$trnlnm("CK_SOURCE")
 $ endif
+$ define K 'ck_source'
 $!
 $! Parse P1: Build options.
 $!
@@ -508,51 +528,80 @@ $   if f$locate( "B", p1) .ne. p1_len then sslolb=1
 $   if f$locate( "D", p1) .ne. p1_len then debug=1
 $   if f$locate( "F", p1) .ne. p1_len then large_file=0
 $   if f$locate( "I", p1) .ne. p1_len then internal_ftp=0
+$   if f$locate( "J", p1) .ne. p1_len then internal_http=0
 $   if f$locate( "L", p1) .ne. p1_len then mathlevel=1
 $   if f$locate( "M", p1) .ne. p1_len then nomms=1
-$   if f$locate( "N", p1) .ne. p1_len
-$   then
-$     net_option="NONET"
-$     internal_ftp=0
-$   endif
 $   if f$locate( "O", p1) .ne. p1_len then mmsclm = 1024
 $   if f$locate( "S", p1) .ne. p1_len then noshare=0
 $   if f$locate( "V", p1) .ne. p1_len then verify=1
 $   if f$locate( "W", p1) .ne. p1_len then On Warning then goto warning_exit
 $   if f$locate( "X", p1) .ne. p1_len then do_ckvcvt=1
+$   if f$locate( "N", p1) .ne. p1_len
+$   then
+$     net_option="NONET"
+$     internal_ftp=0
+$     internal_http=0
+$   endif
 $ endif
 $!
-$! Parse P3: C macros (including SSL).
+$! Parse P3: C macros (primarily CK_SSL[=vrsn]).
 $!
-$ p3_len = f$length( p3)
 $ v_ssl = 0
-$ if (p3 .nes. "") .and. (f$locate( "CK_SSL", p3) .ne. p3_len)
+$ vssl_vrsn = ""
+$ if (p3 .nes. "")
 $ then
-$   ssl = 1
-$   if (f$locate( "CK_SSL111", p3) .ne. p3_len)
+$   p3_len = f$length( p3)
+$   ssl_start = f$locate( "CK_SSL=", p3)
+    if (ssl_start .ne. p3_len) ! CK_SSL=
 $   then
-$     ssl111 = 1
-$     p3 = p3+ ",CK_SSL"        ! Ensure that "CK_SSL" is (also) defined.
+$     ssl = 1
+$     v_ssl = 1
+$! Analyze (and strip out) optional CK_SSL[=vrsn] argument.
+$     ssl_spec = f$element( 0, ",", f$extract( ssl_start, p3_len, p3))
+$     ssl_spec_len = f$length( ssl_spec)
+$     vssl_vrsn_start = f$locate( "=", ssl_spec)
+      vssl_vrsn = f$extract( vssl_vrsn_start+ 1, ssl_spec_len, ssl_spec)
+$     vssl_vrsn = f$edit( vssl_vrsn, "TRIM")
+$     v_ssl = vssl_vrsn .nes. ""
+$! Complain about missing "vrsn" argument.
+$     if (vssl_vrsn .eqs. "")
+$     then
+$       write sys$output -
+ "FATAL: ""CK_SSL=vrsn"" specified without ""vrsn""."
+$       write sys$output ""
+$       goto The_exit
+$     endif
+$! Excise "=vrsn" from P3.
+$     p3_1 = f$extract( 0, (ssl_start+ 6), p3)
+$     p3_2 = f$extract( (ssl_start+ssl_spec_len), p3_len, p3)
+$     p3 = p3_1+ p3_2
 $     p3_len = f$length( p3)
-$   endif
-$   if (f$locate( "CK_SSL0", p3) .eq. p3_len)
+$! Complain about missing explicit vendor SSL.
+$     ssl_lnm = "SSL"+ vssl_vrsn+ "$INCLUDE"
+$     if (f$trnlnm( ssl_lnm) .eqs. "")
+$     then
+$       write sys$output -
+ "FATAL: You specified that vendor SSL (''vssl_vrsn') be used, but the"
+$       write sys$output -
+ "       required logical names (''ssl_lnm') have not been defined."
+$       write sys$output ""
+$       goto The_exit
+$     endif
+$   else ! CK_SSL=
+$     ssl = (f$locate( "CK_SSL", p3) .ne. p3_len)
+$   endif ! CK_SSL=
+$!
+$   if (ssl)
 $   then
-$     p3 = p3+ ",OPENSSL_100"   ! Define "OPENSSL_100", unless "CK_SSL0".
-$   endif
-$ endif
+$     if (f$locate( "CK_SSL0", p3) .eq. p3_len) ! CK_SSL0
+$     then
+$       p3 = p3+ ",OPENSSL_100"   ! Define "OPENSSL_100", unless "CK_SSL0".
+$     endif ! CK_SSL0
+$   endif ! ssl
+$ endif ! (p3 .nes. "")
 $!
 $ if (ssl)
 $ then
-$   if ((f$trnlnm( "OSSL$INCLUDE") .eqs. "") .and. -
-     (f$trnlnm( "SSL111$INCLUDE") .eqs. "") .and. -
-     ((f$trnlnm( "SSL3$INCLUDE") .eqs. "") .or. (ssl111 .ne. 0)))
-$   then
-$     type sys$input
-FATAL: You specified that OpenSSL be used, but the required logical names
-       have not been defined.
-
-$     goto The_exit
-$   endif
 $! Choose between object libraries and shared images for SSL.
 $   if (sslolb)
 $   then
@@ -560,27 +609,44 @@ $     ssl_link = "OLB"
 $   else
 $     ssl_link = "EXE"
 $   endif
-$! Distinguish between VSI SSL and OpenSSL, based on OpenSSL logical names.
-$! Any OpenSSL (OSSL$*") overrides any VSI SSL ("SSL111$*", "SSL3$*").
-$! VSI SSL3 preferred over SSL111 unless used specified SSL111.
 $!
-$   v_ssl = f$trnlnm( "OSSL$INCLUDE") .eqs. ""
-$   if (v_ssl)
+$   if (.not. v_ssl)
 $   then
-$     if ((f$trnlnm("SSL3$INCLUDE") .nes. "") .and. (ssl111 .eq. 0))
+$     if ((f$trnlnm( "OSSL$INCLUDE") .eqs. "") .and. -
+       (f$trnlnm( "SSL111$INCLUDE") .eqs. "") .and. -
+       (f$trnlnm( "SSL3$INCLUDE") .eqs. ""))
 $     then
-$       ssl_brand = "(vendor (3), "+ ssl_link+ ") "
-$     else
-$       ssl_brand = "(vendor (111), "+ ssl_link+ ") "
-$       ssl111 = 3              ! No SSL3, or user specified SSL111.
+$       type sys$input
+FATAL: You specified that (Open)SSL be used, but no required logical names
+       have been defined.
+
+$       goto The_exit
 $     endif
-$   else
-$     ssl_brand = "(OpenSSL, "+ ssl_link+ ") "
-$   endif
-$   ssl_text = "SSL "+ ssl_brand+ "support and"
-$ else
-$   ssl_text = ""
-$ endif
+$!
+$! No explicit vendor SSL selected, so look for (in order):
+$!   User-built OpenSSL  (OSSL$INCLUDE)
+$!   Vendor SSL3         (SSL3$INCLUDE)
+$!   Vendor SSL111       (SSL111$INCLUDE)
+$!
+$     v_ssl = f$trnlnm( "OSSL$INCLUDE") .eqs. ""
+$     if (v_ssl)
+$     then
+$       if (f$trnlnm("SSL3$INCLUDE") .nes. "")
+$       then
+$         ssl_brand = "(vendor (3), "+ ssl_link+ ") "
+$         vssl_vrsn = "3"
+$       else
+$         ssl_brand = "(vendor (111), "+ ssl_link+ ") "
+$         vssl_vrsn = "111"
+$       endif
+$     else ! (v_ssl)
+$       ssl_brand = "(OpenSSL, "+ ssl_link+ ") "
+$     endif ! (v_ssl)
+$     ssl_text = "SSL "+ ssl_brand+ "support and"
+$   else ! (.not. v_ssl)
+$     ssl_text = ""
+$   endif ! (.not. v_ssl)
+$ endif ! (ssl)
 $!
 $ cln_def = ""
 $ if p3 .nes. "" then cln_def = ","+ p3         ! comma delimited string
@@ -595,58 +661,49 @@ $! Find the "openssl" command executable.
 $   openssl_cmd = ""
 $   if (v_ssl)
 $   then
-$     if (ssl111 .ne. 0)
-$     then
-$       openssl_cmd = "$ SSL111$EXE:OPENSSL.EXE"
-$     else
-$       openssl_cmd = "$ SSL3$EXE:OPENSSL.EXE"
-$     endif
+$     openssl_cmd = "$ SSL"+ vssl_vrsn+ "$EXE:OPENSSL.EXE"
 $   else
 $     openssl_exe = f$search( "OSSL$EXE:openssl*.EXE")
 $     openssl_cmd = "$ OSSL$EXE:"+ -
       f$parse( openssl_exe, , , "NAME", "SYNTAX_ONLY")+ ".EXE"
-$   endif
+$   endif ! (v_ssl)
 $!
 $   if (openssl_cmd .eqs. "")
 $   then
 $     type sys$input
 FATAL: Cannot determine the OpenSSL version installed.  Ensure that the
-appropriate SSL set-up procedure has been run.
+       appropriate SSL set-up procedure has been run.
 
 $     goto The_exit
 $   endif
-$   define/user sys$output openssl_version.tmp
+$   temp_file_name = "openssl_version.tmp"
+$   define/user sys$output 'temp_file_name'
 $   openssl_cmd version
 $   close/nolog LOG
-$   open/read LOG openssl_version.tmp
+$   open/read LOG 'temp_file_name'
 $   read LOG line
 $   close LOG
-$   delete_ openssl_version.tmp;
+$   delete_ 'temp_file_name';
 $   ssl_version = f$element(1," ",f$edit(line,"compress"))
 $   if ssl_version .lts. "1.1.1"
 $   then
 $     say -
-"FATAL: OpenSSL version ''ssl_version' is older than 1.1.1, which is too old."
+ "FATAL: OpenSSL version ''ssl_version' is older than 1.1.1, which is too old."
 $     goto The_exit
 $   else
 $     say "OpenSSL ''ssl_version' found"
 $   endif
-$ endif
+$ endif ! (ssl)
 $!
 $! If necessary, define the logical name OPENSSL for #include directives.
 $!
-$ if ssl
+$ if (ssl)
 $ then
 $   openssl_proc = f$edit( f$trnlnm( "OPENSSL", "LNM$PROCESS"), "UPCASE")
 $   openssl_orig = f$edit( f$trnlnm( "OPENSSL"), "UPCASE")
 $   if v_ssl
 $   then
-$     if (ssl111 .ne. 0)
-$     then
-$       openssl_new = "SSL111$INCLUDE:"
-$     else
-$       openssl_new = "SSL3$INCLUDE:"
-$     endif
+$     openssl_new = "SSL"+ vssl_vrsn+ "$INCLUDE:"
 $   else
 $     openssl_new = "OSSL$INCLUDE:[OPENSSL]"
 $   endif
@@ -665,7 +722,7 @@ $     endif
 $   endif
 $   define OPENSSL 'openssl_new'
 $   openssl_def = 1
-$ endif
+$ endif ! (ssl)
 $!
 $! P1 "D", debug option.
 $!
@@ -700,12 +757,13 @@ $! Find out which Kermit version we are building
 $! (from CKCMAI.C's ck_s_ver variable declaration)
 $!
 $ ck_version = "9.0.299"
-$ search /exact /nostatistic /output=ck_version.tmp -
+$ temp_file_name = "ck_version.tmp"
+$ search /exact /nostatistic /output = 'temp_file_name' -
       K:ckcmai.c "char *ck_s_ver = "
-$ open /read /error=end_version VERSION_TMP ck_version.tmp
+$ open /read /error=end_version VERSION_TMP 'temp_file_name'
 $ read /error=end_version VERSION_TMP line
 $ close VERSION_TMP
-$ delete ck_version.tmp;
+$ delete 'temp_file_name';
 $ ck_version = f$element(1,"""",line)
 $end_version:
 $!
@@ -742,10 +800,10 @@ $   write optf "ckvtio.obj"
 $   write optf "ckvcon.obj"
 $   write optf "ckvioc.obj"
 $   write optf "ckusig.obj"
+$   write optf "ckvrtl.obj"
 $   if internal_ftp
 $   then
 $     write optf "ckcftp.obj"
-$     write optf "ckvrtl.obj"
 $   endif
 $   write optf "Identification=""Kermit ''ck_version'"""
 $!
@@ -756,32 +814,20 @@ $     write optf "ck_crp.obj"
 $     write optf "ck_ssl.obj"
 $     if (v_ssl)
 $     then
-$       if (ssl111 .ne. 0)
+$       if (sslolb)
 $       then
-$! Vendor SSL111.
-$         if (sslolb)
-$         then
 $! Object libraries.
-$           write optf "SSL111$LIB:SSL111$LIBSSL32.OLB/library"
-$           write optf "SSL111$LIB:SSL111$LIBCRYPTO32.OLB/library"
-$         else ! sslolb
+$         write optf -
+           "SSL"+ vssl_vrsn+ "$LIB:SSL"+ vssl_vrsn+ "$LIBSSL32.OLB/library"
+$         write optf -
+           "SSL"+ vssl_vrsn+ "$LIB:SSL"+ vssl_vrsn+ "$LIBCRYPTO32.OLB/library"
+$       else ! sslolb
 $! Shared images.
-$           write optf "SYS$SHARE:SSL111$LIBSSL_SHR32.EXE/shareable"
-$           write optf "SYS$SHARE:SSL111$LIBCRYPTO_SHR32.EXE/shareable"
-$         endif ! sslolb
-$       else ! ssl111
-$! Vendor SSL3.
-$         if (sslolb)
-$         then
-$! Object libraries.
-$           write optf "SSL3$LIB:SSL111$LIBSSL32.OLB/library"
-$           write optf "SSL3$LIB:SSL111$LIBCRYPTO32.OLB/library"
-$         else ! sslolb
-$! Shared images.
-$           write optf "SYS$SHARE:SSL3$LIBSSL_SHR32.EXE/shareable"
-$           write optf "SYS$SHARE:SSL3$LIBCRYPTO_SHR32.EXE/shareable"
-$         endif ! sslolb
-$       endif ! ssl111
+$         write optf -
+           "SYS$SHARE:SSL"+ vssl_vrsn+ "$LIBSSL_SHR32.EXE/shareable"
+$         write optf -
+           "SYS$SHARE:SSL"+ vssl_vrsn+ "$LIBCRYPTO_SHR32.EXE/shareable"
+$       endif ! sslolb
 $     else ! v_ssl
 $! OpenSSL.  (Use newer "OSSL$*" logical names).
 $       if (sslolb)
@@ -841,6 +887,15 @@ $ then
 $   say "DECC compiler found"
 $   cc_ver = "DECC"
 $   ccopt = "/decc/unsigned_char"+ccopt
+$!
+$   temp_file_name = "cc_vers.tmp"
+$   define /user_mode sys$output 'temp_file_name'
+$   cc /version
+$   open /read temp_file 'temp_file_name'
+$   read temp_file cc_version
+$   close temp_file
+$   delete 'temp_file_name';*
+$!
 $   goto compile
 $ endif
 $!
@@ -948,6 +1003,34 @@ $     non_vax=1
 $   endif
 $ endif
 $!
+$! Record architecture, source location, C compiler version string, and
+$! DCL parameters in build-log (.blog) file. 
+$!
+$ blogfilename = procbasename+ ".blog"
+$ create /fdl = sys$input 'blogfilename'
+RECORD
+        FORMAT stream_lf
+$!
+$ open /append blog_file 'blogfilename' 
+$ write blog_file "ARCH="+ arch
+$ write blog_file "CC_VERSION="+ -
+   f$extract( 0, f$locate( " on", cc_version), cc_version)
+$ if (ssl_version .nes. "")
+$ then
+$   ssl_version = "OpenSSL "+ ssl_version
+$ endif
+$ write blog_file "SSL_VERSION="+ ssl_version
+$ write blog_file "CK_SOURCE="+ ck_source
+$ write blog_file "P1="+ p1o
+$ write blog_file "P2="+ p2o
+$ write blog_file "P3="+ p3o
+$ write blog_file "P4="+ p4
+$ write blog_file "P5="+ p5o
+$ write blog_file "P6="+ p6
+$ close blog_file
+$!
+$! Announce.
+$!
 $ say f$fao("!/Operating System: OpenVMS(tm) !AS!/", arch)
 $!
 $! cc_ver could start with DECC, GNUC, or VAXC, or be specified by the
@@ -1041,6 +1124,7 @@ $ if net_option .eqs. "NONET"
 $ then
 $   net_name = "no"
 $   internal_ftp = 0
+$   internal_http = 0
 $ else
 $   havetcp = 1
 $   if net_option .eqs. "MULTINET"
@@ -1069,6 +1153,10 @@ $        else
 $          if net_option .eqs. "DEC_TCPIP"                      ! +1.24
 $          then
 $            net_name = "DEC TCP/IP Services for OpenVMS(tm)"
+$            if f$search("tcpip$library:tcpip$lib.olb") .nes.""  ! 1.50
+$            then
+$              write optf "tcpip$library:tcpip$lib/library"
+$            endif
 $            if non_vax .eq. 0
 $            then
 $              if ucxv5
@@ -1166,13 +1254,23 @@ $ if vmsv8 then cln_def = cln_def+",VMSV80"
 $ if ucxv5 then cln_def = cln_def+",UCX50"
 $ if if_dot_h then cln_def = cln_def+",IF_DOT_H"
 $ if havetcp then cln_def = cln_def+",TCPSOCKET"
-$ if vms_ver .lts. "VMS_V62" then cln_def = cln_def+",NOHTTP,NOCMDATE2TM"
+$ if vms_ver .lts. "VMS_V62"
+$ then
+$   cln_def = cln_def+",NOHTTP,NOCMDATE2TM"
+$   internal_http = 0
+$ endif
 $!!! if vms_ver .lts. "VMS_V72" then cln_def = cln_def+",NOSETTIME"
 $!
 $ if_def=""
 $ if internal_ftp
 $ then
-$  if_def=",NEWFTP"
+$  if_def = if_def+ ",NEWFTP"
+$ endif
+$ if internal_http
+$ then
+$  if_def = if_def+ ",CKHTTP"
+$ else
+$  if_def = if_def+ ",NOHTTP"
 $ endif
 $!
 $! LARGE_FILE NOTES :
@@ -1192,7 +1290,7 @@ $ lf_def=""
 $ if large_file .and. non_vax.eq.0 ! Disable for VAX
 $ then
 $  large_file=0
-$  say "Large file support disabled becuase: VAX"
+$  say "Large file support disabled because: VAX"
 $ endif
 $!
 $ if large_file .and. vms_ver .lts. "VMS_V73" ! Disable for VMS pre-7.3
@@ -1255,6 +1353,24 @@ $   say ""
 $   show symb ccopt
 $   show symb lopt
 $!
+$   say "  Compiling CKWART at ''f$time()"
+$!
+$! Note the use of apostrophe (') rather than quotation mark (") in quoting
+$! CCOPT, to prevent CCOPT from being expanded prior to the MAKE call,
+$! which could result in the string being too long.  Using ' rather than "
+$! forces evaluation of CCOPT to occur in the MAKE routine itself.
+$!
+$   CALL MAKE ckwart.OBJ "'CC' 'CCOPT' K:ckwart" -
+          "K:ckwart.c K:ckcsym.h K:ckcdeb.h K:ckclib.h"
+$   say "  Linking CKWART at ''f$time()"
+$!
+$   CALL MAKE ckwart.exe "LINK  ckwart,aux.opt/opt/NOMAP" ckwart.obj
+$   say "  Running CKWART at ''f$time()"
+$   ckwart = "$" +f$parse("CKWART.EXE",,,"DEVICE") +-
+            f$parse("CKWART.EXE",,,"DIRECTORY") + "CKWART"
+$   CALL MAKE ckcpro.c "ckwart  K:ckcpro.w ckcpro.c" -
+          "K:ckcpro.w" K:ckcsym.h
+$!
 $   say f$fao("!/  Compiling WERMIT files at ''f$time()")
 $!
 $! Note how MAKE args are combined in quotes to get around the limitation
@@ -1285,7 +1401,10 @@ $     CALL MAKE ckcftp.obj "'CC' 'CCOPT' K:ckcftp" -
             "K:ckucmd.h K:ckuusr.h K:ckcnet.h K:ckvioc.h" -
             "K:ckctel.h K:ckcxla.h K:ckuxla.h K:ckcuni.h" -
             "K:ckuath.h K:ckvrtl.h K:ck_ssl.h"
+$   endif
 $!
+$   if internal_ftp .or. internal_http
+$   then
 $     CALL MAKE ckvrtl.obj "'CC' 'CCOPT' K:ckvrtl" -
             "K:ckvrtl.c K:ckvrtl.h"
 $   endif
@@ -1501,8 +1620,12 @@ $!
 $CLEAN_ALL:
 $ if f$search("ccflags.mms") .nes. "" then delete/noconf/log ccflags.mms;*
 $ if f$search("ckcpro.c")    .nes. "" then delete/noconf/log ckcpro.c;*
+$ if f$search("ckvblog.txt") .nes. "" then delete/noconf/log ckvblog.txt;*
+$ if f$search("shofeat.txt") .nes. "" then delete/noconf/log shofeat.txt;*
 $ if f$search("*.exe")       .nes. "" then delete/noconf/log *.exe;*
+$ if f$search("*.blog")      .nes. "" then delete/noconf/log *.blog;*
 $ if f$search("*.opt")       .nes. "" then delete/noconf/log *.opt;*
+
 $CLEAN:
 $ if f$search("*.obj")       .nes. "" then delete/noconf/log *.obj;*
 $ if f$search("*.lis")       .nes. "" then delete/noconf/log *.lis;*

--- a/ckvker.mms
+++ b/ckvker.mms
@@ -1,12 +1,10 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! 2007-02-27 SMS.
-# Updated 2022-11-18 to remove references to wart and ckcpro.w.
-! Actual VMS dependencies.
+! 2025-03-24 SMS.
 
 .FIRST
-    @ ! echo: write to stdout; tab: some spacing
-    @ echo = "write sys$output"
-    @ tab = "    "
+	@ ! echo: write to stdout; tab: some spacing
+	@ echo = "write sys$output"
+	@ tab = "    "
 .include ccflags.mms
 
 SHAREOPTS = KERMIT.OPT/OPTION
@@ -29,31 +27,41 @@ OBJECT_MODULES = ckcfn2.obj, ckcfn3.obj, ckcfns.obj, $(CKCFTP_OBJ), -
 ! Rule Section:
 !
 .C.OBJ :
-    @ echo tab + "Compiling ''f$trnlnm("K")'$(MMS$SOURCE)" - "K:"
-    @ $(CC) $(CCFLAGS) /object=$(MMS$TARGET) $(MMS$SOURCE)
+	@ echo tab + "Compiling ''f$trnlnm("K")'$(MMS$SOURCE)" - "K:"
+	@ $(CC) $(CCFLAGS) /object=$(MMS$TARGET) $(MMS$SOURCE)
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 ! Dependencies Section:
 !
 ALL :   wermit.exe  ckvcvt.exe
-    @ continue
+	@ continue
 
 WERMIT :   wermit.exe
-    @ continue
+	@ continue
 
 CKVCVT :   ckvcvt.exe
-    @ continue
+	@ continue
 
 wermit.exe : $(OBJECT_MODULES)
-    @ echo tab + "Linking $(MMS$TARGET_NAME)"
+	@ echo tab + "Linking $(MMS$TARGET_NAME)"
 
-       $(LINK) $(LINKFLAGS) -
-        /exec=wermit.exe $(SHAREOPTS)
+	$(LINK) $(LINKFLAGS) -
+         /exec=wermit.exe $(SHAREOPTS)
+
+ckcpro.c : K:ckcpro.w ckwart.exe K:ckcdeb.h K:ckcasc.h K:ckcker.h
+	@ echo "CKWART $(MMS$SOURCE) CKCPRO.C"
+	@ ckwart = "$" + f$parse("CKWART.EXE",,,"DEVICE") + -
+	 f$parse("CKWART.EXE",,,"DIRECTORY") + "CKWART"
+	@ ckwart K:ckcpro.w ckcpro.c
 
 ckvcvt.exe : ckvcvt.obj
-    @ echo tab + "Linking $(MMS$TARGET_NAME)"
-        $(LINK) $(LINKFLAGS) ckvcvt.obj, aux.opt /options
+	@ echo tab + "Linking $(MMS$TARGET_NAME)"
+	$(LINK) $(LINKFLAGS) ckvcvt.obj, aux.opt /options
+
+ckwart.exe : ckwart.obj
+	@ echo tab + "Linking $(MMS$TARGET_NAME)"
+	$(LINK) /nodebug/nomap ckwart.obj, aux.opt /options
 
 
 ! Object file dependencies:
@@ -77,7 +85,7 @@ ckcftp.obj : K:ckcftp.c K:ckcsym.h K:ckcdeb.h K:ckclib.h -
              K:ckvrtl.h K:ck_ssl.h
 
 ckclib.obj : K:ckclib.c K:ckcsym.h K:ckcdeb.h K:ckclib.h -
-             K:ckcasc.h
+             K:ckcasc.h 
 
 ckcmai.obj : K:ckcmai.c K:ckcsym.h K:ckcasc.h K:ckcdeb.h -
              K:ckclib.h K:ckcker.h K:ckcnet.h K:ckvioc.h -
@@ -89,8 +97,10 @@ ckcnet.obj : K:ckcnet.c K:ckcsym.h K:ckcdeb.h K:ckclib.h -
              K:ckctel.h K:ck_ssl.h K:ckuusr.h K:ckucmd.h -
              K:ckuath.h K:ckcsig.h K:ckvrtl.h
 
-ckcpro.obj : K:ckcpro.c K:ckcker.h K:ckcdeb.h K:ckcsym.h -
+ckcpro.obj : ckcpro.c K:ckcker.h K:ckcdeb.h K:ckcsym.h -
              K:ckcasc.h K:ckclib.h
+	@ echo "Compiling $(MMS$SOURCE)
+	@ $(CC) $(CCFLAGS)/INCLUDE_DIRECTORY=K: $(MMS$SOURCE)
 
 ckctel.obj : K:ckctel.c K:ckcsym.h K:ckcdeb.h K:ckclib.h -
              K:ckcker.h K:ckcnet.h K:ckvioc.h K:ckctel.h -
@@ -188,6 +198,8 @@ ckvrtl.obj : K:ckvrtl.c K:ckvrtl.h
 ckvtio.obj : K:ckvtio.c K:ckcdeb.h K:ckclib.h K:ckcasc.h -
              K:ckcker.h K:ckvvms.h K:ck_ssl.h K:ckcnet.h -
              K:ckvioc.h K:ckctel.h
+
+ckwart.obj : K:ckwart.c K:ckcsym.h K:ckcdeb.h K:ckclib.h
 
 ck_crp.obj : K:ck_crp.c K:ckcsym.h K:ckcdeb.h K:ckclib.h -
              K:ckcnet.h K:ckvioc.h K:ckctel.h

--- a/ckvrms.h
+++ b/ckvrms.h
@@ -18,7 +18,7 @@
 #  define FAB_OR_NAML_FNS naml$l_long_filename_size
 
 #  define FAB_L_NAMX fab$l_naml
-#  define NAMX NAML
+#  define NAMX_STRUCT NAML
 #  define NAMX_C_MAXRSS NAML$C_MAXRSS
 #  define NAMX_M_NOCONCEAL NAML$M_NOCONCEAL
 #  define NAMX_M_SEARCH_LIST NAML$M_SEARCH_LIST
@@ -52,6 +52,8 @@
 #  define NAMX_L_TYPE naml$l_long_type
 #  define NAMX_B_VER naml$l_long_ver_size
 #  define NAMX_L_VER naml$l_long_ver
+#  define NAMX_DNA_FNA_SET( fab) (fab).fab$l_dna = (char *) -1; \
+    (fab).fab$l_fna = (char *) -1;
 #  define CC_RMS_NAMX cc$rms_naml
 
 #else /* def NAML$C_BID */
@@ -65,7 +67,7 @@
 #  define FAB_OR_NAML_FNS fab$b_fns
 
 #  define FAB_L_NAMX fab$l_nam
-#  define NAMX NAM
+#  define NAMX_STRUCT NAM
 #  define NAMX_C_MAXRSS NAM$C_MAXRSS
 #  define NAMX_M_NOCONCEAL NAM$M_NOCONCEAL
 #  define NAMX_M_SEARCH_LIST NAM$M_SEARCH_LIST
@@ -99,6 +101,7 @@
 #  define NAMX_L_TYPE nam$l_type
 #  define NAMX_B_VER nam$b_ver
 #  define NAMX_L_VER nam$l_ver
+#  define NAMX_DNA_FNA_SET( fab);
 #  define CC_RMS_NAMX cc$rms_nam
 
 #endif /* def NAML$C_BID [else] */

--- a/ckvrtl.c
+++ b/ckvrtl.c
@@ -114,7 +114,7 @@ struct atrdef ut_atr[ 3] = {
 
 struct FAB ut_fab = cc$rms_fab;
 struct RAB ut_rab = cc$rms_rab;
-struct NAMX ut_namx = CC_RMS_NAMX;
+struct NAMX_STRUCT ut_namx = CC_RMS_NAMX;
 static struct fibdef ut_fib;
 
 /* Device and file name buffers and their descriptors. */
@@ -131,7 +131,7 @@ struct dsc$descriptor fib_dsc =
 
 #ifdef __DECC
 
-/* We will accept either a UNIX-like path name or a VMS-like path name.
+/* We will accept either a UNIX-like path name or a VMS-like path name. 
    If a slash is found in the name, assume that it's UNIX-like, and
    convert it to VMS form.  Otherwise, use it as-is.
 */
@@ -398,3 +398,4 @@ int dmy_lib$initialize = (int) LIB$INITIALIZE;
 #pragma standard
 
 #endif /* !defined( __VAX) && (__CRTL_VER >= 70301000) */
+

--- a/ckvtio.c
+++ b/ckvtio.c
@@ -1148,7 +1148,7 @@ ttinl(dest,max,timo,eol,start,turn) int max,timo,turn; CHAR *dest,eol,start;
 #endif /* NOXFER */
 #endif /* TTXBUF */
 
-sig_t saval;               /* For saving alarm handler */
+SIGTYP (*saval)() = NULL;               /* For saving alarm handler */
 
 VOID
 ttimoff() {                             /* Turn off any timer interrupts */
@@ -2207,7 +2207,7 @@ ttsspd(cps) int cps; {
 
 /*  C O N I N T  --  Console Interrupt setter  */
 
-static sig_t cctrap;
+static SIGTYP (*cctrap)();
 
 VOID
 #ifdef CK_ANSIC
@@ -2581,9 +2581,28 @@ gtimer() {
 }
 
 #ifdef GFTIMER
-#ifdef VMSI64
-/* The native VMS code is broken in VMS/IA64 8.1. */
-/* Luckily, in VMS 8.1 we can use the Unix code. */
+
+/* 2024-05-16 SMS.  Original code using sys$gettim() used
+ * lib$cvtf_from_internal_time() to get to floating-point (FP), which
+ * produced VAX FP values.  This failed when IEEE FP was used, which
+ * became the default beginning with IA64 hardware.  Old/unnatural
+ * work-around:
+ *
+ *    #ifdef VMSI64
+ */   /*  The native VMS code is broken in VMS/IA64 8.1. */   /*
+ */   /* Luckily, in VMS 8.1 we can use the Unix code. */     /*
+ *
+ * This condition fails on x86_64, or with CC/FLOAT=IEEE_FLOAT (on
+ * Alpha, for example), because the condition of interest is the FP
+ * style in use, not the hardware architecture.
+ *
+ * Modified code uses sys$gettim() everyplace, and tests the FP style,
+ * not the hardware architecture (using lib$cvts_from_internal_time()
+ * for IEEE FP).  Define GFTIMER_UNIX to get the (still available)
+ * alternate (gettimeofday(), et al.) scheme.
+ */
+
+#ifdef GFTIMER_UNIX  /* Alternate scheme using gettimeofday(), et al. */
 
 static struct timeval tzero;
 
@@ -2595,7 +2614,7 @@ rftimer() {
 CKFLOAT
 gftimer() {
     struct timeval tnow, tdelta;
-    CKFLOAT s;
+    CKFLOAT fp_time;
 #ifdef DEBUG
     char fpbuf[64];
 #endif /* DEBUG */
@@ -2608,20 +2627,29 @@ gftimer() {
 	tdelta.tv_sec--;
 	tdelta.tv_usec += 1000000;
     }
-    s = (CKFLOAT) tdelta.tv_sec + ((CKFLOAT) tdelta.tv_usec / 1000000.0);
-    if (s < GFMINTIME)
-      s = GFMINTIME;
+    fp_time = (CKFLOAT) tdelta.tv_sec + ((CKFLOAT) tdelta.tv_usec / 1000000.0);
+    if (fp_time < GFMINTIME)
+      fp_time = GFMINTIME;
 #ifdef DEBUG
     if (deblog) {
-	sprintf(fpbuf,"%f",s);
+	sprintf(fpbuf,"%f",fp_time);
 	debug(F110,"gftimer",fpbuf,0);
     }
 #endif /* DEBUG */
-    return(s);
+    return(fp_time);
 }
 
+#else /* def GFTIMER_UNIX */ /* Original scheme using sys$gettim(), et al. */
 
+#if __IEEE_FLOAT
+#define CVTS
+#endif /* __IEEE_FLOAT */
+
+#ifdef CVTS
+#define LIB_CVTX_FROM_INTERNAL_TIME lib$cvts_from_internal_time /* IEEE */
 #else
+#define LIB_CVTX_FROM_INTERNAL_TIME lib$cvtf_from_internal_time /* VAX */
+#endif /* def CVTS */
 
 static QUAD tzero;
 
@@ -2637,32 +2665,33 @@ rftimer() {
 
 CKFLOAT
 gftimer() {
-    float s;                            /* gcc gawks at CKFLOAT */
+    float fp_time;                      /* gcc gawks at CKFLOAT */
     QUAD tnow, diff;                    /* 64-bit times */
     int status;
-    unsigned long lkd = LIB$K_DELTA_SECONDS_F;
+    unsigned int lkd = LIB$K_DELTA_SECONDS_F;   /* "_F": Fractional. */
 #ifdef DEBUG
     char fpbuf[64];
 #endif /* DEBUG */
     status = sys$gettim(&tnow);
     if (!(status & 1)) vms_lasterr = status;
     debug(F101,"gftimer status 1","",status);
-    status = lib$sub_times(&tnow, &tzero, &diff );
+    status = lib$sub_times(&tnow, &tzero, &diff );  /* (Delta_time < 0.) */
     if (!(status & 1)) vms_lasterr = status;
     debug(F101,"gftimer status 2","",status);
-    status = lib$cvtf_from_internal_time(&lkd,&s,&diff);
+    status = LIB_CVTX_FROM_INTERNAL_TIME(&lkd,&fp_time,&diff);
     if (!(status & 1)) vms_lasterr = status;
     debug(F101,"gftimer status 3","",status);
 #ifdef DEBUG
     if (deblog) {
-        sprintf(fpbuf,"%f",s);
-        debug(F110,"gftimer s",fpbuf,0);
+        sprintf(fpbuf,"%f",fp_time);
+        debug(F110,"gftimer fp_time",fpbuf,0);
     }
 #endif /* DEBUG */
-    return(s > 0.0 ? (CKFLOAT) s : (CKFLOAT) 0.000001);
+    return(fp_time > 0.0 ? (CKFLOAT) fp_time : (CKFLOAT) 0.000001);
 }
-#endif	/* VMSI64 */
+#endif	/* def GFTIMER_UNIX [else] */
 #endif /* GFTIMER */
+
 
 /*  Z T I M E  --  Return date/time string  */
 


### PR DESCRIPTION
Both myself and Steven  Schweda were involved in the testing of C-Kermit 10.0 Beta.12 and submitted changes to
Frank da Cruz for the OpenVMS platform (VAX, Alpha, Itanium and x86_64).  Due to Frank's illness he was unable
to get them included in future updates.

What I have done is restored our changed files to a forked repository of OpenKermit/ckermit (they are ckv* files)
and tested a build under VSI OpenVMS x86_64 V9.2-3 using the VSI C V7.7-003 compiler.

With these OpenVMS files and a trivial change to support IPv6 under VSI TCPIP V6.0-30 - I have confirmed
a working version under OpenVMS x86_64 both with OpenSSL3 and without SSL support (OpenVMS has no
support for SSL4 yet).

```
$ run wermit-ssl3

You can have C-Kermit execute any commands you want when it starts
by putting them in your initialization file, which is:

 * Unix (Linux, BSD, macOS, etc): .kermrc in your home (login) directory
 * Windows: k95custom.ini \v(appdata) (your application data directory)
 * IBM OS/2: k2custom.ini \v(appdata) (your application data directory)
 * VMS, OpenVMS: ckermit.ini Your home (login) directory
 * Other: ckermit.ini Your home (login) directory

C-Kermit 11.0.506, 2026/08/03, for OpenVMS(tm) x86_64+SSL
 Copyright (C) 1985, 2025,
  Trustees of Columbia University in the City of New York.
 Copyright (C) 2025-2026, John Goerzen
 Open Source 3-clause BSD license since 2011.
Type ? or HELP for help.
USER_DISK:[LOCAL.SOURCES.CKERMIT11] C-Kermit>show version

Versions:
 C-Kermit 11.0.506, 2026/08/03
 Numeric: 1100506
 Built for:  OpenVMS x86_64
 Running on: OpenVMS x86_64 9 V9.2-3   x86_64
 Patches: (none)
 Communications I/O 10.0.125, 4 October 2022 for OpenVMS x86_64
 File support, 10.0.185, 4 October 2022 for OpenVMS x86_64
 C-Kermit library, 11.0.500, 22 Jul 2026
 C-Kermit Protocol Module 11.0.500, 22 Jul 2026
 C-Kermit functions, 11.0.506, 03 Aug 2026
 Command package 11.0.500, 22 July 2026
 User Interface 10.0.332, 02 May 2023
 Character Set Translation 10.0.045, 15 Apr 2023
 CONNECT Command 10.0.064 4 October 2022
 Dial Command, 10.0.165, 15 Apr 2023
 Script Command, 10.0.033, 15 Apr 2023
 Network support, 11.0.500, 22 Jul 2026
 Telnet support, 11.0.500, 22 Jul 2026
 FTP Client, 11.0.500, 22 Jul 2026
 Authentication, 11.0.500, 22 Jul 2026
 SSL/TLS support, 11.0.500 22 Jul 2026

USER_DISK:[LOCAL.SOURCES.CKERMIT11] C-Kermit>show features
C-Kermit 11.0.506, 2026/08/03
DUGONG$DKA100:[LOCAL.SOURCES.CKERMIT11]wermit-ssl3.exe, size: 4499456

Major features included:
 Large files and large integers (64 bits)
 Network support (type SHOW NET for further info)
 Telnet Kermit Option
 Telnet Authentication Option
 Secure Sockets Layer (SSL)
 Transport Layer Security (TLS)
 Telnet Remote Com Port Control Option
 Built-in FTP client
 Built-in HTTP client
 Latin-1 (West European) character-set translation
 Latin-2 (East European) character-set translation
 Cyrillic (Russian, Ukrainian, etc) character-set translation
 Greek character-set translation
 Hebrew character-set translation
 Japanese character-set translation
 Unicode character-set translation
 RESEND command
 Fullscreen file transfer display
 Control-character unprefixing
 Streaming
 Autodownload

Major optional features not included:
 No built-in XYZMODEM protocols
 No Kerberos(TM) authentication
 No SRP(TM) (Secure Remote Password) authentication
 No Telnet Encryption Option
 No X Windows forwarding
 No SOCKS
 No arrow-key support
 No hardware flow control
 No REDIRECT or PIPE command
 No Internet Kermit Service

Host info:
 Machine:    x86_64
 Model:      innotek GmbH VirtualBox
 OS:         OpenVMS x86_64
 OS Release: V9.2-3  
 OS Version: 9

Compiled Aug  4 2026 18:49:33, options:
 __CRTL_VER=90230000 __DECC __DECC_VER=70790003 __STDC__ __VMS_VER=90230022
 __x86_64 _LARGEFILE_SOURCE _POSIX_JOB_CONTROL _SC_JOB_CONTROL ARRAYREFLEN=1024
 BIGBUFOK CK_ANSIC CK_ANSILIBS CK_APC CK_AUTODL CK_CURSES CK_ENVIRONMENT CK_FAST
 CK_LABELED CK_MKDIR CK_NAWS CK_PCT_BAR CK_PERMS CK_RECALL CK_SPEED CK_SSL
 CK_TIMERS CK_TMPDIR CK_TTGWSIZ CK_TTYFD CK_WREFRESH CKFLOAT=float CKHTTP CKLEARN
 CKMAXOPEN=64 CKMAXPATH=4095 CKREALPATH CKREGEX CKTUNING CMDBL=32763 CMDDEP=64
 CONGSPD COPYINTERPRET DCMDBUF DEC_TCPIP DEVNAMLEN=4095 DYNAMIC FD_SETSIZE=1024
 FNFLOAT FOPEN_MAX=8 FORDEPTH=32 GFTIMER h_addr HADDRLIST IFDEBUG IKS_OPTION
 INBUFSIZE=32768 INPBUFSIZ=4096 LINBUFSIZ=32773 MAC_MAX=16384 MACLEVEL=128
 MAXDDIR=32 MAXDNUMS=4095 MAXGETPATH=128 MAXTAKE=54 MAXWLD=102400 MDMHUP
 MSENDMAX=1024 NETCONN NETLEBUF NEWFTP NO_DNS_SRV NO_PARAM_H NOARROWKEYS NOKVERBS
 NOSETBUF NOSYSLOG NOVMSSHARE NOWTMP OBUFSIZE=32768 OPEN_MAX=8
 OPENSSL_VERSION_TEXT="OpenSSL 3.0.20 7 Apr 2026" OS2ORVMS PARSENSE RLOGCODE SIG_V
 SO_DONTROUTE SO_KEEPALIVE SO_LINGER SO_OOBINLINE SO_RCVBUF SO_SNDBUF SOL_SOCKET
 STREAMING TCPSOCKET TIMEH TLOG TMPBUFSIZ=32773 TN_COMPORT TNCODE TTSPDLIST
 TYPEINTERPRET UCX50 UIDBUFLEN=256 UNPREFIXZERO USE_MEMCPY UTIMEH VMS vms VMSORUNIX
 VMSV60 VMSV70 VMSV80 VNAML=4096 WHATAMI XFRCAN z_maxchan=46 Z_MAXCHAN=46 ZXREWIND

 byte order: little endian

 sizeofs: int=4 long=4 off_t=8 CK_OFF_T=8 size_t=4 short=2 char=1 char*=4 float=4
 double=8

 floating-point: precision=16 rounding=1

USER_DISK:[LOCAL.SOURCES.CKERMIT11] C-Kermit>
```

This was built using the ```CKVKER.COM``` DCL command file that invokes the MMS build in ```CKVKER.MMS```.

I've only had a chance to verify the binary works against a copy of CP/M Kermit to transfer a few files back and forth in server mode over a serial port via a LAT connected terminal server.

I also tried to build it on both VAX (OpenVMS V7.3 with Compaq c V6.4-005) and Alpha (VSI OpenVMS V8.4-2L1 with VSI C V7.4-002) and it fails to compile modules with the updated prototypes.  I need to do some more investigation into whether I can coax these old compilers to accept the code.

Hopefully this is useful to anyone wishing to run the latest C-Kermit under OpenVMS (at least x86_64) for now.

Tony

