### PR TITLE
Fix -Wsign-compare and related bug

### DIFF
--- a/ck_crp.c
+++ b/ck_crp.c
@@ -3967,7 +3967,7 @@ static int
 cast_fb64_start(struct cast_fb *fbp, int dir, int server)
 {
     Block b;
-    int x;
+    unsigned int x;
     unsigned char *p;
     int state;
 
@@ -4263,7 +4263,7 @@ cast_fb64_session(Session_Key *key, int server, struct cast_fb *fbp, int fs)
     }
 
     /* Stuff leftovers into the feed */
-    if(key->length >= 2 * klen + sizeof(Block))
+    if((size_t)key->length >= 2 * klen + sizeof(Block))
         memcpy(fbp->temp_feed, key->data + 2 * klen, sizeof(Block));
     else {
         memset(fbp->temp_feed, 0, sizeof(Block));

--- a/ck_ssl.c
+++ b/ck_ssl.c
@@ -2171,7 +2171,7 @@ ssl_tn_init(mode) int mode;
             */
             n = snprintf(cert_filepath, sizeof(cert_filepath), "%s/%s",
                 defdir, "telnetd-rsa.pem");
-            if (n < 0 || n >= sizeof(cert_filepath)) {
+            if (n < 0 || (size_t)n >= sizeof(cert_filepath)) {
                 debug(F110, "ssl_tn_init", "cert_filepath truncation", 0);
                 last_ssl_mode = -1;
                 return(0);
@@ -2186,7 +2186,7 @@ ssl_tn_init(mode) int mode;
             */
             n = snprintf(cert_filepath, sizeof(cert_filepath), "%s/%s",
                 defdir, "telnetd-rsa-key.pem");
-            if (n < 0 || n >= sizeof(cert_filepath)) {
+            if (n < 0 || (size_t)n >= sizeof(cert_filepath)) {
                 debug(F110, "ssl_tn_init", "cert_filepath truncation", 0);
                 last_ssl_mode = -1;
                 return(0);
@@ -2201,7 +2201,7 @@ ssl_tn_init(mode) int mode;
             */
             n = snprintf(cert_filepath, sizeof(cert_filepath), "%s/%s",
                 defdir, "telnetd-dsa.pem");
-            if (n < 0 || n >= sizeof(cert_filepath)) {
+            if (n < 0 || (size_t)n >= sizeof(cert_filepath)) {
                 debug(F110, "ssl_tn_init", "cert_filepath truncation", 0);
                 last_ssl_mode = -1;
                 return(0);
@@ -2216,7 +2216,7 @@ ssl_tn_init(mode) int mode;
             */
             n = snprintf(cert_filepath, sizeof(cert_filepath), "%s/%s",
                 defdir, "telnetd-dsa-key.pem");
-            if (n < 0 || n >= sizeof(cert_filepath)) {
+            if (n < 0 || (size_t)n >= sizeof(cert_filepath)) {
                 debug(F110, "ssl_tn_init", "cert_filepath truncation", 0);
                 last_ssl_mode = -1;
                 return(0);
@@ -2231,7 +2231,7 @@ ssl_tn_init(mode) int mode;
             */
             n = snprintf(cert_filepath, sizeof(cert_filepath), "%s/crl",
                 defdir);
-            if (n < 0 || n >= sizeof(cert_filepath)) {
+            if (n < 0 || (size_t)n >= sizeof(cert_filepath)) {
                 debug(F110, "ssl_tn_init", "cert_filepath truncation", 0);
                 last_ssl_mode = -1;
                 return(0);
@@ -3024,7 +3024,7 @@ ssl_get_dNSName(ssl) SSL * ssl;
                 if (!gen->d.ia5 || !CK_ASN1_STRING_LEN(gen->d.ia5))
                   break;
                 if (strlen((char *)CK_ASN1_STRING_DATA(gen->d.ia5)) !=
-                    CK_ASN1_STRING_LEN(gen->d.ia5)) {
+                    (size_t)CK_ASN1_STRING_LEN(gen->d.ia5)) {
                     /* Ignoring IA5String containing null character */
                     continue;
                 }
@@ -3075,7 +3075,7 @@ ssl_get_commonName(ssl) SSL * ssl;
     if (name_text_len <= 0) {
         /* Common Name was empty or not retrieved */
         err = 0;
-    } else if (strlen(name) != name_text_len) {
+    } else if (strlen(name) != (size_t)name_text_len) {
         /* Ignoring Common Name containing null character */
         err = 0;
     } else {
@@ -3408,7 +3408,7 @@ tls_get_SAN_objs(SSL * ssl, int type)
                 if (!gen->d.ia5 || !CK_ASN1_STRING_LEN(gen->d.ia5))
                   break;
                 if (strlen((char *)CK_ASN1_STRING_DATA(gen->d.ia5)) !=
-                    CK_ASN1_STRING_LEN(gen->d.ia5)) {
+                    (size_t)CK_ASN1_STRING_LEN(gen->d.ia5)) {
                     /* Ignoring IA5String containing null character */
                     continue;
                 }
@@ -3987,7 +3987,7 @@ ssl_is(data,cnt) unsigned char *data; int cnt;
                 n = snprintf(errbuf, sizeof(errbuf),
                     "[SSL - SSL_accept error: %s",
                     ERR_error_string(ERR_get_error(), NULL));
-                if (n < 0 || n >= sizeof(errbuf)) {
+                if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                     debug(F110, "ssl_is", "errbuf truncation", 0);
                 }
 
@@ -4106,7 +4106,7 @@ ck_tn_tls_negotiate(VOID)
                 n = snprintf(errbuf, sizeof(errbuf),
                     "[TLS - SSL_accept error: %s",
                     ERR_error_string(ERR_get_error(), NULL));
-                if (n < 0 || n >= sizeof(errbuf)) {
+                if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                     debug(F110, "ck_tn_tls_negotiate", "errbuf truncation", 0);
                 }
 
@@ -4407,7 +4407,7 @@ ck_ssl_incoming(fd) int fd;
             n = snprintf(errbuf, sizeof(errbuf),
                 "[TLS - SSL_accept error: %s",
                 ERR_error_string(ERR_get_error(), NULL));
-            if (n < 0 || n >= sizeof(errbuf)) {
+            if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                 debug(F110, "ck_ssl_incoming", "errbuf truncation", 0);
             }
 
@@ -4446,7 +4446,7 @@ ck_ssl_incoming(fd) int fd;
             n = snprintf(errbuf, sizeof(errbuf),
                 "[SSL - SSL_accept error: %s",
                 ERR_error_string(ERR_get_error(), NULL));
-            if (n < 0 || n >= sizeof(errbuf)) {
+            if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                 debug(F110, "ck_ssl_incoming", "errbuf truncation", 0);
             }
 
@@ -4588,7 +4588,7 @@ ck_ssl_outgoing(fd) int fd;
             n = snprintf(errbuf, sizeof(errbuf),
                 "[TLS - SSL_connect error: %s",
                 ERR_error_string(ERR_get_error(), NULL));
-            if (n < 0 || n >= sizeof(errbuf)) {
+            if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                 debug(F110, "ck_ssl_outgoing", "errbuf truncation", 0);
             }
 
@@ -4675,7 +4675,7 @@ ck_ssl_outgoing(fd) int fd;
                 n = snprintf(errbuf, sizeof(errbuf),
                     "[SSL - SSL_connect error: %s",
                     ERR_error_string(ERR_get_error(), NULL));
-                if (n < 0 || n >= sizeof(errbuf)) {
+                if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                     debug(F110, "ck_ssl_outgoing", "errbuf truncation", 0);
                 }
                 printf("%s\r\n",errbuf);
@@ -4779,7 +4779,7 @@ ck_ssl_http_client(fd, hostname) int fd; char * hostname;
             n = snprintf(errbuf, sizeof(errbuf),
                 "[TLS - SSL_connect error: %s",
                 ERR_error_string(ERR_get_error(), NULL));
-            if (n < 0 || n >= sizeof(errbuf)) {
+            if (n < 0 || (size_t)n >= sizeof(errbuf)) {
                 debug(F110, "ck_ssl_http_client", "errbuf truncation", 0);
             }
 

--- a/ckcfn2.c
+++ b/ckcfn2.c
@@ -3058,7 +3058,7 @@ rpack() {
         break;
       case 2:                           /* Type 2, 12-bit checksum */
         x = xunchar(*pbc) << 6 | xunchar(pbc[1]);
-        if (x != chk2(recpkt+lp,j-lp)) { /* No match */
+        if ((unsigned int)x != chk2(recpkt+lp,j-lp)) { /* No match */
             if (type == 'E') {          /* Allow E packets to have type 1 */
                 recpkt[j++] = pbc[0];
                 recpkt[j] = '\0';
@@ -3109,7 +3109,7 @@ rpack() {
       case 4:                           /* Type 4 = Type 2, no blanks. */
         x = (unsigned)((xunchar(*pbc) - 1) << 6) |
           (unsigned)(xunchar(pbc[1]) - 1);
-        if (x != chk2(recpkt+lp,j-lp)) {
+        if ((unsigned int)x != chk2(recpkt+lp,j-lp)) {
             if (type == 'E') {  /* Allow E packets to have type 1 */
                 recpkt[j++] = pbc[0];
                 recpkt[j] = '\0';

--- a/ckcfns.c
+++ b/ckcfns.c
@@ -638,7 +638,7 @@ bdecode(buf,fn) register CHAR *buf; register int (*fn)();
         a = *xdbuf++ & 0xff;            /* Get next character */
         len--;
         rpt = 0;                        /* Initialize repeat count. */
-        if (a == rptq && rptflg) {      /* Got a repeat prefix? */
+        if (a == (unsigned int)rptq && rptflg) { /* Repeat prefix? */
             rpt = xunchar(*xdbuf++ & 0xFF); /* Yes, get the repeat count, */
             rptn += rpt;
             a = *xdbuf++ & 0xFF;        /* and get the prefixed character. */
@@ -1373,14 +1373,14 @@ decode(buf,fn,xlate) register CHAR *buf; register int (*fn)(); int xlate;
     while (len > 0) {                   /* Loop for each byte */
         a = *xdbuf++ & 0xff;            /* Get next character */
         len--;
-        if (a == rptq && rptflg) {      /* Got a repeat prefix? */
+        if (a == (unsigned int)rptq && rptflg) { /* Repeat prefix? */
             rpt = xunchar(*xdbuf++ & 0xFF); /* Yes, get the repeat count, */
             rptn += rpt;
             a = *xdbuf++ & 0xFF;        /* and get the prefixed character. */
             len -= 2;
         }
         b8 = lsstate ? 0200 : 0;        /* 8th-bit value from SHIFT-STATE */
-        if (ebqflg && a == ebq) {       /* Have 8th-bit prefix? */
+        if (ebqflg && a == (unsigned int)ebq) { /* 8th-bit prefix? */
             b8 ^= 0200;                 /* Yes, invert the 8th bit's value, */
             ssflg = 1;                  /* remember we did this, */
             a = *xdbuf++ & 0xFF;        /* and get the prefixed character. */

--- a/ckcftp.c
+++ b/ckcftp.c
@@ -789,7 +789,7 @@ static char *fncnam[] = {
 
 /* Used to speed up text-mode PUTs */
 #define zzout(fd,c) \
-((fd<0)?(-1):((nout>=ucbufsiz)?(zzsend(fd,c)):(ucbuf[nout++]=c)))
+((fd<0)?(-1):((nout>=(unsigned int)ucbufsiz)?(zzsend(fd,c)):(ucbuf[nout++]=c)))
 
 #define CHECKCONN() if(!connected){printf("%s\n",nocx);return(-9);}
 
@@ -15862,8 +15862,9 @@ secure_write(fd, buf, nbyte)
         }
         return(send(fd,(SENDARG2TYPE)buf,nbyte,0));
     } else {
-        int ucbuflen = (maxbuf ? maxbuf : actualbuf) - FUDGE_FACTOR;
-        int bsent = 0;
+        unsigned int ucbuflen = (maxbuf ? maxbuf : actualbuf) -
+            FUDGE_FACTOR;
+        unsigned int bsent = 0;
 
         while (bsent < nbyte) {
             int b2cp = ((nbyte - bsent) > (ucbuflen - nout) ?
@@ -16198,7 +16199,8 @@ secure_getbyte(fd,fc) int fd,fc;
                                );
                   return(ERR);
               }
-              if ((kerror = looping_read(fd,(char *)ucbuf,length)) != length) {
+              if ((unsigned int)(kerror =
+                  looping_read(fd,(char *)ucbuf,length)) != length) {
                   secure_error("Couldn't read %u byte PROT buffer: %s",
                                length,
                                kerror == -1 ? ck_errstr() : "premature EOF"

--- a/ckclib.c
+++ b/ckclib.c
@@ -2540,7 +2540,7 @@ b64tob8( s, n, out, len ) char * s; int n; char * out; int len;
         r = 0;
         return(0);
     }
-    x = (n < 0) ? strlen(s) : n;        /* Source length */
+    x = (n < 0) ? (int)strlen(s) : n;   /* Source length */
 
     n = ((x + 3) / 4) * 3;              /* Compute destination length */
     if (x > 0 && s[x-1] == '=') n--;    /* Account for padding */
@@ -2814,7 +2814,7 @@ hextoulong(s,n) char *s; int n;
         } else {
             return(-1L);
         }
-        if (++count > (sizeof(long) * 2))
+        if ((size_t)(++count) > sizeof(long) * 2)
           return(-1L);
         result = (result << 4) | (d & 0x0f);
     }

--- a/ckctel.c
+++ b/ckctel.c
@@ -1976,7 +1976,7 @@ fwdx_create_fake_xauth(name, name_len, data_len)
     for (n = 0; n < sizeof(stackdata); n++)
         c += stackdata[n];
     srand((unsigned int)c);
-    for (c = 0; c < data_len; c++)
+    for (c = 0; c < (unsigned int)data_len; c++)
         fake_xauth.data[c] = (unsigned char)rand();
     return 0;
 }

--- a/ckuath.c
+++ b/ckuath.c
@@ -2383,7 +2383,7 @@ auth_send(parsedat,end_sub) unsigned char *parsedat; int end_sub;
 {
     static unsigned char buf[4096];
     unsigned char *pname;
-    int plen;
+    unsigned int plen;
     int i;
     int mode;
 #ifdef MIT_CURRENT
@@ -3618,7 +3618,7 @@ auth_name(parsedat,end_sub) unsigned char *parsedat; int end_sub;
 #endif
 {
     int len = (end_sub-2) > 63 ? 63 : (end_sub-2);
-    if ( len > 0 && (len + 1) < sizeof(szUserNameRequested)) {
+    if ( len > 0 && (size_t)(len + 1) < sizeof(szUserNameRequested)) {
         memcpy(szUserNameRequested,&parsedat[2],len);           /* safe */
         szUserNameRequested[len] = '\0';
     } else

--- a/ckufio.c
+++ b/ckufio.c
@@ -6715,7 +6715,7 @@ whoami() {
         ckstrncpy(envname, c, 255);
         debug(F110,"whoami envname",envname,0);
         if ((p = getpwnam(envname)) != NULL) {
-            if (p->pw_uid == ruid) {    /* get passwd entry for envname */
+            if (p->pw_uid == (uid_t)ruid) { /* get passwd entry for envname */
                 ckstrncpy(realname, envname, UIDBUFLEN); /* uid's are same */
                 debug(F110,"whoami realname",realname,0);
                 return(realname);
@@ -6729,7 +6729,7 @@ whoami() {
         ckstrncpy (loginname, c, UIDBUFLEN);
         debug(F110,"whoami loginname",loginname,0);
         if ((p = getpwnam(loginname)) != NULL) /* get passwd entry */
-          if (p->pw_uid == ruid)        /* for loginname */
+          if (p->pw_uid == (uid_t)ruid) /* for loginname */
             ckstrncpy(realname, envname, UIDBUFLEN); /* if uid's are same */
     }
 

--- a/ckupty.c
+++ b/ckupty.c
@@ -501,7 +501,7 @@ copy_termbuf( char *cp, int len )
 copy_termbuf(cp, len) char *cp; int len;
 #endif /* CK_ANSIC */
 {
-    if (len > sizeof(termbuf))
+    if ((size_t)len > sizeof(termbuf))
       len = sizeof(termbuf);
     memcpy((char *)&termbuf, cp, len);
     termbuf2 = termbuf;

--- a/ckutio.c
+++ b/ckutio.c
@@ -11501,7 +11501,7 @@ ttinc(timo) int timo;
           return((unsigned)(n & 0xff));
         else
 #endif /* TNCODE */
-          return(n < 0 ? n : (unsigned)(n & ttpmsk));
+          return(n < 0 ? n : (n & ttpmsk));
 
 #else  /* MYREAD */
 
@@ -11596,7 +11596,7 @@ debug(F110,"XXX netclos in ifdef NETCONN...","C",0);
         else
 #endif /* TNCODE */
           /* Return masked char or neg. */
-          return( (n < 0) ? n : (unsigned)(n & ttpmsk) );
+          return( (n < 0) ? n : (n & ttpmsk) );
     }
 }
 
@@ -16427,7 +16427,7 @@ ckxfprintf(va_alist) va_dcl
         }
         len = rc;
         for (i = 0, j = 0, got_cr = 0;
-             i < len && j < sizeof(str1)-2;
+             i < len && (size_t)j < sizeof(str1)-2;
              i++, j++ ) {
             /* We can't use 255 as a case label because of signed chars */
             c = (unsigned)(str1[i] & 0xff);
@@ -16552,7 +16552,7 @@ ckxprintf(va_alist) va_dcl
         }
         len = rc;
         for (i = 0, j = 0, got_cr=0;
-             i < len && j < sizeof(str1)-2;
+             i < len && (size_t)j < sizeof(str1)-2;
              i++, j++ ) {
             c = (unsigned)(str1[i] & 0xff);
 #ifdef TNCODE

--- a/ckuus4.c
+++ b/ckuus4.c
@@ -1295,7 +1295,7 @@ initfloat() {
         y = i - 1;
         debug(F111,"initfloat 4.0/9.0",buf,y);
         fp_digits = (x < y) ? x : y;
-        if (fp_digits < sizeof(math_pi) - 1) {
+        if ((size_t)fp_digits < sizeof(math_pi) - 1) {
             math_pi[fp_digits+1] = NUL;
             math_e[fp_digits+1] = NUL;
         }
@@ -11061,14 +11061,14 @@ fneval(fn,argp,argn,xp) char *fn, *argp[]; int argn; char * xp;
         while (1) {
             if (!eof1) {
                 c1 = getc(fp1);
-                if (c1 == (unsigned int)EOF) {
+                if (c1 == EOF) {
                     eof1++;
                     fclose(fp1);
                 }
             }
             if (!eof2) {
                 c2 = getc(fp2);
-                if (c2 == (unsigned int)EOF) {
+                if (c2 == EOF) {
                     eof2++;
                     fclose(fp2);
                 }
@@ -12927,14 +12927,14 @@ fneval(fn,argp,argn,xp) char *fn, *argp[]; int argn; char * xp;
             while (!eof) {              /* Loop for each marker */
                 while (!eof) {          /* Find next marker */
                     c = getc(fp);
-                    if (c == (unsigned int)EOF) {
+                    if (c == EOF) {
                         eof++;
                         break;
                     }
                     if (c == 0xff) {
                         buf[0] = c;
                         c = getc(fp);
-                        if (c == (unsigned int)EOF) {
+                        if (c == EOF) {
                             eof++;
                             break;
                         }
@@ -13610,7 +13610,7 @@ char *                                  /* Evaluate builtin variable */
       case VN_FULLVER:                  /* Full version number (edit 400) */
       {
           extern char *ck_s_ver, *ck_s_edit, *ck_s_test, *ck_s_tver;
-          if (x > strlen(ck_s_test)) {
+          if ((size_t)x > strlen(ck_s_test)) {
               sprintf(vvbuf,"%s.%s %s.%s",
                       ck_s_ver, ck_s_edit, ck_s_test, ck_s_tver); /* SAFE */
           } else {

--- a/ckuusr.c
+++ b/ckuusr.c
@@ -8143,15 +8143,17 @@ isinternalmacro(x) int x;
         internal = ckindex(m,"|_while|_forx|_forz|_xif|_switx|",0,0,0);
         debug(F111," internal macro","A",internal);
         if (!internal) {
-            int i, n, len = 0;
+            int n, len = 0;
+            unsigned int i;
             n = -1;
-            for (i = 0; i < sizeof(* tags); i++) {
+            for (i = 0; i < sizeof(tags) / sizeof(tags[0]); i++) {
                 if (ckindex(tags[i],m,0,0,0)) {
                     n = i;
                     break;
                 }
             }
-            debug(F111," tags index",tags[n],n);
+            if (n > -1)
+              debug(F111," tags index",tags[n],n);
             if (n > -1) {
                 char * tag = tags[i];
                 len = (int)strlen(tag);

--- a/ckuusx.c
+++ b/ckuusx.c
@@ -10322,7 +10322,7 @@ getslot() {                             /* Find a free slot for us */
     /* Trim stale records from end */
 
 #ifndef NOFTRUNCATE
-    if (i > dblastused+DB_RECL) {
+    if ((unsigned long)i > dblastused+DB_RECL) {
         debug(F101,"getslot truncating at","",DB_HDRL+dblastused+DB_RECL);
 #ifdef COHERENT
         x = chsize(fileno(dbfp),DB_HDRL+dblastused+DB_RECL);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def debug_log_command(debug_log):
     gz_path = compressed_debug_log_path(debug_log)
     return (
         "set debug timestamps on, "
-        f"log debug {{|trap '' HUP; exec gzip -c > {gz_path}}}"
+        f"log debug {{|trap '' HUP; exec gzip -1 -c > {gz_path}}}"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -455,7 +455,13 @@ def run_wermit(wermit_path):
     Synchronously runs a wermit command or script, returning a CompletedProcess.
     Can accept a list of arguments or a string command (executed via -C).
     """
-    def _run(args, input_data=None, timeout=10):
+    def _run(args, input_data=None, timeout=10, pre_timeout_callback=None):
+        """Run wermit and return a CompletedProcess.
+
+        If pre_timeout_callback is specified, invoke it 2 seconds before
+        the hard timeout (or immediately if timeout <= 2) to capture live
+        state before termination.
+        """
         if isinstance(args, str):
             # Automatically skip init file, suppress banner, run inline
             # command with more-prompting off, and append exit to prevent
@@ -470,13 +476,36 @@ def run_wermit(wermit_path):
 
         logger.info("run_wermit: Launching process: %s", " ".join(cmd))
         t_start = time.perf_counter()
-        result = subprocess.run(
-            cmd,
-            input=input_data,
-            capture_output=True,
-            text=True,
-            timeout=timeout
-        )
+        if pre_timeout_callback is None:
+            result = subprocess.run(
+                cmd,
+                input=input_data,
+                capture_output=True,
+                text=True,
+                timeout=timeout
+            )
+        else:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE if input_data else None,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            snapshot_at = max(timeout - 2, 0)
+            try:
+                stdout, stderr = proc.communicate(
+                    input=input_data, timeout=snapshot_at)
+                result = subprocess.CompletedProcess(
+                    cmd, proc.returncode, stdout, stderr)
+            except subprocess.TimeoutExpired:
+                pre_timeout_callback()
+                try:
+                    stdout, stderr = proc.communicate(
+                        timeout=timeout - snapshot_at)
+                    result = subprocess.CompletedProcess(
+                        cmd, proc.returncode, stdout, stderr)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    stdout, stderr = proc.communicate()
+                    raise subprocess.TimeoutExpired(
+                        cmd, timeout, output=stdout, stderr=stderr)
         logger.info("run_wermit: Process completed with exit code %d in %.4f seconds",
                     result.returncode, time.perf_counter() - t_start)
         return result
@@ -645,7 +674,10 @@ def wermit_loopback(request, wermit_path, run_wermit, spawn_wermit,
                 try:
                     result = run_wermit(
                         full_client_cmd,
-                        timeout=timeout + TCP_TIMEOUT_MARGIN)
+                        timeout=timeout + TCP_TIMEOUT_MARGIN,
+                        pre_timeout_callback=lambda: _log_socket_snapshot(
+                            "wermit_loopback: client about to time out",
+                            port))
                 except subprocess.TimeoutExpired:
                     # If some other process's  connection lands on this
                     # listener's single accept() before the client in this test
@@ -1042,6 +1074,32 @@ def _log_process_snapshot(label):
     except Exception as e:
         logger.warning(
             "%s: failed to capture process snapshot: %s", label, e)
+
+
+def _log_socket_snapshot(label, port):
+    """Log socket and process state for port.
+
+    Runs netstat to record whether the TCP connection reached ESTABLISHED
+    or remained in SYN_SENT.
+
+    Also invokes _log_process_snapshot to record running processes.
+    """
+    try:
+        ns = subprocess.run(
+            ["netstat", "-an"], capture_output=True, text=True, timeout=5)
+        # BSD netstat uses '.' as port delimiter (127.0.0.1.41000); Linux
+        # uses ':' (127.0.0.1:41000). Match either delimiter and require a
+        # trailing non-digit or end-of-line to avoid prefix matches.
+        port_re = re.compile(rf"[.:]{port}(\D|$)")
+        relevant = "\n".join(
+            line for line in ns.stdout.splitlines() if port_re.search(line)
+        )
+        logger.info(
+            "%s: socket snapshot for port %d:\n%s", label, port, relevant)
+    except Exception as e:
+        logger.warning(
+            "%s: failed to capture socket snapshot: %s", label, e)
+    _log_process_snapshot(label)
 
 
 def _make_controlling_tty():

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -70,3 +70,25 @@ def test_script_control(run_wermit):
     assert "TEST_CONTROL: GOTO loop 3" in result.stdout
     assert "TEST_CONTROL: GOTO loop 4" not in result.stdout
     assert "TEST_CONTROL: GOTO verified" in result.stdout
+
+
+def test_underscore_macro_name_not_internal(run_wermit):
+    """
+    Invoking a user-defined macro whose name starts with "_" but isn't one of
+    the macro names _while, _forx, _forz, _xif, _switx.
+
+    Regression test for isinternalmacro().  It looped
+    "i < sizeof(* tags)", the size of one array element (a char *),
+    instead of the array's element count. tags[] has 4 real entries;
+    sizeof(char *) is 4 on a 32-bit build, so the loop happened to be
+    correct there, but incorrect on 64-bit.
+    """
+    result = run_wermit("define _mytest1 echo hi, do _mytest1")
+
+    assert result.returncode >= 0, (
+        "wermit crashed (signal "
+        f"{-result.returncode}) invoking a user macro named "
+        f"_mytest1: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert_ok(result)
+    assert "hi" in result.stdout


### PR DESCRIPTION
isinternalmacro() had a loop that read past the end of an array.  A user naming a macro with a leading underscore could trigger a segfault. Added a test for this condition and fixed the bug.